### PR TITLE
Include udev rule if -DINSTALL_UDEV_RULES=ON is set (copied from rtl-sdr...

### DIFF
--- a/host/hackrf-tools/52-hackrf.rules
+++ b/host/hackrf-tools/52-hackrf.rules
@@ -1,0 +1,1 @@
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-%k", MODE="666", GROUP="plugdev"

--- a/host/hackrf-tools/CMakeLists.txt
+++ b/host/hackrf-tools/CMakeLists.txt
@@ -62,3 +62,17 @@ add_custom_target(uninstall
     ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 )
 endif()
+
+########################################################################
+# Install udev rules
+########################################################################
+option(INSTALL_UDEV_RULES "Install udev rules for HackRF" OFF)
+if (INSTALL_UDEV_RULES)
+    install (
+        FILES 52-hackrf.rules
+        DESTINATION "/etc/udev/rules.d"
+        COMPONENT "udev"
+        )
+else (INSTALL_UDEV_RULES)
+    message (STATUS "Udev rules not being installed, install them with -DINSTALL_UDEV_RULES=ON")
+endif (INSTALL_UDEV_RULES)


### PR DESCRIPTION
Add option -DINSTALL_UDEV_RULES=ON to cmake to install udev rule
