### PR TITLE
fix permissions on udev rules

### DIFF
--- a/host/hackrf-tools/52-hackrf.rules
+++ b/host/hackrf-tools/52-hackrf.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-%k", MODE="666", GROUP="plugdev"
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-%k", MODE="660", GROUP="plugdev"


### PR DESCRIPTION
when setting a group on a device typically you only set write for root and the group not for world.  should be 660 not 666, 666 is the devil.
