### PR TITLE
Add signal source mode to hackrf_transfer

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -416,8 +416,9 @@ int tx_callback(hackrf_transfer* transfer) {
 		} else {
 			return 0;
 		}
-
-	}
+	} else {
+        return -1;
+    }
 }
 
 static void usage() {


### PR DESCRIPTION
Add a new transceiver mode, named TRANSCEIVER_MODE_SS, which allows the HackRF to act as an analog signal source to generate a pure SINE wave at the given frequency, given power level (0~255) and given amplifier configurations.
