### PR TITLE
MAX2837: Fix register read when dirty

### DIFF
--- a/firmware/common/max2837.c
+++ b/firmware/common/max2837.c
@@ -185,7 +185,7 @@ void max2837_spi_write(uint8_t r, uint16_t v) {
 uint16_t max2837_reg_read(uint8_t r)
 {
 	if ((max2837_regs_dirty >> r) & 0x1) {
-		max2837_spi_read(r);
+		max2837_regs[r] = max2837_spi_read(r);
 	};
 	return max2837_regs[r];
 }


### PR DESCRIPTION
Regardless of the dirty state of a register, the locally modified (but possibly uncommitted) value will always be returned.
