### PR TITLE
Map LIBUSB_ERROR_BUSY to HACKRF_ERROR_BUSY.

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -287,7 +287,12 @@ int ADDCALL hackrf_open(hackrf_device** device)
 	// TODO: Error or warning if not high speed USB?
 
 	result = libusb_set_configuration(usb_device, 1);
-	if( result != 0 )
+	if( result == LIBUSB_ERROR_BUSY )
+	{
+		libusb_close(usb_device);
+		return HACKRF_ERROR_BUSY;
+	}
+	else if( result != LIBUSB_SUCCESS )
 	{
 		libusb_close(usb_device);
 		return HACKRF_ERROR_LIBUSB;


### PR DESCRIPTION
Map LIBUSB_ERROR_BUSY to HACKRF_ERROR_BUSY.
The new Kernel has a [HackRF module](https://github.com/torvalds/linux/blob/f7e87a44ef60ad379e39b45437604141453bf0ec/drivers/media/usb/hackrf/hackrf.c) for v4l2. This module gets automatic loaded on Arch & Backtrack. Before this patch i get simply the message "hackrf_open() failed: HACKRF_ERROR_LIBUSB (-1000)" which is not relay helpful. After this patch i get a more helpfully "hackrf_open() failed: HACKRF_ERROR_BUSY (-6)".

If the pull request is accepted i will write a  entry in the FAQ which describes the problem & provide a solution.