### PR TITLE
Attempt to detect correct group for udev rule

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -5,6 +5,7 @@ project (hackrf_all)
 
 add_subdirectory(libhackrf)
 add_subdirectory(hackrf-tools)
+add_subdirectory(misc)
 
 ########################################################################
 # Create uninstall target

--- a/host/libhackrf/CMakeLists.txt
+++ b/host/libhackrf/CMakeLists.txt
@@ -94,21 +94,3 @@ add_custom_target(uninstall
     ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 )
 endif()
-
-########################################################################
-# Install udev rules
-########################################################################
-option(INSTALL_UDEV_RULES "Install udev rules for HackRF" OFF)
-if (INSTALL_UDEV_RULES)
-    if (NOT UDEV_INSTALL_DIR)
-        set (UDEV_INSTALL_DIR "/etc/udev/rules.d")
-    endif (NOT UDEV_INSTALL_DIR)
-
-    install (
-        FILES 53-hackrf.rules
-        DESTINATION ${UDEV_INSTALL_DIR}
-        COMPONENT "udev"
-        )
-else (INSTALL_UDEV_RULES)
-    message (STATUS "Udev rules not being installed, install them with -DINSTALL_UDEV_RULES=ON")
-endif (INSTALL_UDEV_RULES)

--- a/host/misc/CMakeLists.txt
+++ b/host/misc/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 2.8)
+add_subdirectory(udev)

--- a/host/misc/udev/53-hackrf.rules.in
+++ b/host/misc/udev/53-hackrf.rules.in
@@ -1,0 +1,6 @@
+# HackRF Jawbreaker
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-jawbreaker-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+# HackRF One
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+# HackRF DFU
+ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="@HACKRF_GROUP@"

--- a/host/misc/udev/CMakeLists.txt
+++ b/host/misc/udev/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 2.8)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    SET(SYSTEM_IS_LINUX TRUE)
+    SET(UDEV_OPTION_DEFAULT ON)
+else()
+    SET(SYSTEM_IS_LINUX FALSE)
+    SET(UDEV_OPTION_DEFAULT OFF)
+endif()
+
+option(INSTALL_UDEV_RULES
+    "Install udev rules for the HackRF"
+    ${UDEV_OPTION_DEFAULT}
+)
+
+set(UDEV_RULES_PATH
+    "/etc/udev/rules.d"
+    CACHE STRING
+    "Target directory for udev rule installation. Ensure you have permissions to write to this directory."
+)
+
+if(SYSTEM_IS_LINUX)
+    if(INSTALL_UDEV_RULES)
+        if(NOT DEFINED UDEV_RULES_GROUP)
+            foreach(group usb plugdev)
+                execute_process(COMMAND "getent" group "${group}"
+                                RESULT_VARIABLE _GETENT_RESULT
+                                OUTPUT_QUIET
+                                ERROR_QUIET)
+                if(NOT _GETENT_RESULT)
+                    message(STATUS "Setting udev rule group to - ${group}")
+                    set(UDEV_RULES_GROUP ${group})
+                    break()
+                endif(NOT _GETENT_RESULT)
+            endforeach(group)
+        endif(NOT DEFINED UDEV_RULES_GROUP)
+        if(DEFINED UDEV_RULES_GROUP)
+            set(HACKRF_GROUP "${UDEV_RULES_GROUP}"
+                CACHE STRING "Group to associate HackRF devices with in udev rules")
+            configure_file(${CMAKE_CURRENT_SOURCE_DIR}/53-hackrf.rules.in
+                        ${CMAKE_CURRENT_BINARY_DIR}/53-hackrf.rules
+                        @ONLY
+                        )
+            message(STATUS  "HackRF udev rules will be installed to '${UDEV_RULES_PATH}' upon running 'make install'")
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/53-hackrf.rules
+                    DESTINATION ${UDEV_RULES_PATH}
+                    COMPONENT "udev_rules")
+        else(UDEV_RULES_GROUP)
+            message(STATUS "HackRF udev rules will not be installed because no suitable group was found")
+            message(STATUS "A group can be specified with -DUDEV_RULES_GROUP=<group>")
+        endif(DEFINED UDEV_RULES_GROUP)
+    else(INSTALL_UDEV_RULES)
+        message(STATUS
+                "HackRF udev rules will not be installed because INSTALL_UDEV_RULES=OFF"
+               )
+    endif(INSTALL_UDEV_RULES)
+else(SYSTEM_IS_LINUX)
+    if(INSTALL_UDEV_RULES)
+        message(STATUS "udev rules not supported on this platform. Hide this message via -DINSTALL_UDEV_RULES=Off")
+    endif(INSTALL_UDEV_RULES)
+endif(SYSTEM_IS_LINUX)


### PR DESCRIPTION
Allow udev group to be specified at configuration time, with intelligent defualts.

This should solve the problem for both sides of the plugdev/usb divide.