### PR TITLE
Fix GitHub issue #163 - Detach the kernel driver automatically

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -277,7 +277,6 @@ static int set_hackrf_configuration(libusb_device_handle* usb_device, int config
 	result = libusb_get_configuration(usb_device, &curr_config);
 	if( result != 0 )
 	{
-		libusb_close(usb_device);
 		return HACKRF_ERROR_LIBUSB;
 	}
 
@@ -286,13 +285,11 @@ static int set_hackrf_configuration(libusb_device_handle* usb_device, int config
 		result = detach_kernel_drivers(usb_device);
 		if( result != 0 )
 		{
-			libusb_close(usb_device);
 			return result;
 		}
 		result = libusb_set_configuration(usb_device, config);
 		if( result != 0 )
 		{
-			libusb_close(usb_device);
 			return HACKRF_ERROR_LIBUSB;
 		}
 	}
@@ -300,7 +297,6 @@ static int set_hackrf_configuration(libusb_device_handle* usb_device, int config
 	result = detach_kernel_drivers(usb_device);
 	if( result != 0 )
 	{
-		libusb_close(usb_device);
 		return result;
 	}
 	return LIBUSB_SUCCESS;
@@ -487,6 +483,7 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 	result = set_hackrf_configuration(usb_device, USB_CONFIG_STANDARD);
 	if( result != LIBUSB_SUCCESS )
 	{
+		libusb_close(usb_device);
 		return result;
 	}
 
@@ -919,8 +916,6 @@ int ADDCALL hackrf_cpld_write(hackrf_device* device,
 	{
 		return result;
 	}
-	result = libusb_set_configuration(device->usb_device, 2);
-
 
 	result = libusb_claim_interface(device->usb_device, 0);
 	if (result != LIBUSB_SUCCESS) {

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -240,7 +240,7 @@ static int prepare_transfers(
 
 static int detach_kernel_drivers(libusb_device_handle* usb_device_handle)
 {
-	int i, result;
+	int i, num_interfaces, result;
 	libusb_device* dev;
 	struct libusb_config_descriptor* config;
 
@@ -251,7 +251,9 @@ static int detach_kernel_drivers(libusb_device_handle* usb_device_handle)
 		return HACKRF_ERROR_LIBUSB;
 	}
 
-	for(i=0; i<config->bNumInterfaces; i++)
+	num_interfaces = config->bNumInterfaces;
+	libusb_free_config_descriptor(config);
+	for(i=0; i<num_interfaces; i++)
 	{
 		result = libusb_kernel_driver_active(usb_device_handle, i);
 		if( result < 0 )


### PR DESCRIPTION
Adds detach_kernel_drivers() and set_hackrf_configuration() functions.

detach_kernel_drivers() detaches drivers from all interfaces on the active config

set_hackrf_configuration() uses detach_kernel_drivers() to detach the drivers from the interface, then changes the config and then detaches any new drivers that may have attached themselves automatically after the config change.