### PR TITLE
fix bug #192 : hackrf_transfer -n  breaks when used with -R.

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -388,6 +388,10 @@ int tx_callback(hackrf_transfer* transfer) {
 		if ((bytes_read != bytes_to_read)
 				|| (limit_num_samples && (bytes_to_xfer == 0))) {
                        if (repeat) { // added by scateu. repeat mode.
+			       if (limit_num_samples){
+				    //  reset bytes_to_xfer
+				    bytes_to_xfer = samples_to_xfer * 2ull;
+			       }
                                printf("Input file end reached. Rewind to beginning.\n");
                                rewind(fd);
                                fread(transfer->buffer + bytes_read, 1, bytes_to_read - bytes_read, fd);


### PR DESCRIPTION
```
fix bug #192 : hackrf_transfer -n (number of samples) breaks when used with -R.
```
