### PR TITLE
rad1o USB idProduct cleanups

### DIFF
--- a/host/libhackrf/53-hackrf.rules.in
+++ b/host/libhackrf/53-hackrf.rules.in
@@ -2,7 +2,12 @@
 ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-jawbreaker-%k", MODE="660", GROUP="@HACKRF_GROUP@"
 # HackRF One
 ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="@HACKRF_GROUP@"
-# HackRF One
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="CC15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@"
-# HackRF DFU
+# rad1o
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="cc15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+# NXP Semiconductors DFU mode (HackRF and rad1o)
 ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+# rad1o "full flash" mode
+KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0042", SYMLINK+="rad1o-flash-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+# rad1o flash disk
+KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0082", SYMLINK+="rad1o-msc-%k", MODE="660", GROUP="@HACKRF_GROUP@"
+#

--- a/host/python/max2837_dump.py
+++ b/host/python/max2837_dump.py
@@ -32,9 +32,9 @@ else:
     if device:
         print 'Find: HackRF One'
     else:
-        device = usb.core.find(idVendor=0x1d50, idProduct=0xCC15)
+        device = usb.core.find(idVendor=0x1d50, idProduct=0xcc15)
         if device:
-            print 'Find: Rad1o'
+            print 'Find: rad1o'
         else:
         print 'Not find any HackRF device.'
         sys.exit()

--- a/host/python/set_transceiver_mode.py
+++ b/host/python/set_transceiver_mode.py
@@ -31,9 +31,9 @@ else:
     if device:
         print 'Find: HackRF One'
     else:
-        device = usb.core.find(idVendor=0x1d50, idProduct=0xCC15)
+        device = usb.core.find(idVendor=0x1d50, idProduct=0xcc15)
         if device:
-            print 'Find: Rad1o'
+            print 'Find: rad1o'
         else:
             print 'Not find any HackRF device.'
             sys.exit()


### PR DESCRIPTION
- udev rule should be lowercase (https://github.com/rad1o/f1rmware/pull/29)
- add entries for rad1o storage from https://github.com/rad1o/f1rmware/blob/master/smartflash/90-rad1o-flash.rules
- Rad1o -> rad1o
- hackrf.h was NOT adjusted to lowercase cc15