### PR TITLE
Comment style fixup to prevent warning in c90 complier mode

### DIFF
--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -208,4 +208,4 @@ extern ADDAPI uint32_t ADDCALL hackrf_compute_baseband_filter_bw(const uint32_t 
 } // __cplusplus defined.
 #endif
 
-#endif//__HACKRF_H__
+#endif /*__HACKRF_H__*/


### PR DESCRIPTION
In ansi/c90 mode gcc warns about extra tokens at end of #endif directive [-Wendif-labels] when hackrf.h gets included. Changing the comment style gets rid off that.
