### PR TITLE
fix(hackrf-core): Disable unused clock outputs

### DIFF
--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -588,7 +588,11 @@ void pin_setup(void) {
 	scu_pinmux(SCU_PINMUX_LED3, SCU_GPIO_NOPULL);
 	
 	scu_pinmux(SCU_PINMUX_EN1V8, SCU_GPIO_NOPULL);
-	
+
+	/* Disable unused clock outputs. They generate noise. */
+	scu_pinmux(CLK0, SCU_CLK_IN | SCU_CONF_FUNCTION7);
+	scu_pinmux(CLK2, SCU_CLK_IN | SCU_CONF_FUNCTION7);
+
 	/* Configure USB indicators */
 #if (defined JELLYBEAN || defined JAWBREAKER)
 	scu_pinmux(SCU_PINMUX_USB_LED0, SCU_CONF_FUNCTION3);


### PR DESCRIPTION
CLK0 and CLK2 are clock outputs of the LPC43xx which are are activated by default.

During the rad1o development we identified them as sources of interference in the received spectrum (also on the HackRF).

I believe they are not used by anyone. We've disabled them in our rad1o fork.