### PR TITLE
Support both commonly available versions of dfu-util (0.7/0.8)

### DIFF
--- a/firmware/dfu-util.cmake
+++ b/firmware/dfu-util.cmake
@@ -1,0 +1,56 @@
+#
+# Copyright 2015 Dominic Spill <dominicgs@gmail.com>
+#
+# This file is part of GreatFET.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+execute_process(
+	COMMAND dfu-suffix -V
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+	RESULT_VARIABLE DFU_NOT_FOUND
+	ERROR_QUIET
+	OUTPUT_VARIABLE DFU_VERSION_STRING
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(DFU_ALL "")
+if(NOT DFU_NOT_FOUND)
+	string(REGEX REPLACE ".*([0-9]+)\\.[0-9]+.*" "\\1" DFU_VERSION_MAJOR "${DFU_VERSION_STRING}")
+	string(REGEX REPLACE ".*[0-9]+\\.([0-9])+.*" "\\1" DFU_VERSION_MINOR "${DFU_VERSION_STRING}")
+	MESSAGE( STATUS "DFU utils version: " ${DFU_VERSION_MAJOR} "." ${DFU_VERSION_MINOR})
+	execute_process(
+	        COMMAND dfu-prefix -V
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+		RESULT_VARIABLE DFU_PREFIX_NOT_FOUND
+		ERROR_QUIET
+		OUTPUT_VARIABLE DFU_PREFIX_VERSION_STRING
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(DFU_PREFIX_NOT_FOUND)
+		set(DFU_COMMAND dfu-suffix --vid=0x1fc9 --pid=0x000c --did=0x0 -s 0 -a _tmp.dfu)
+	else(DFU_PREFIX_NOT_FOUND)
+		set(DFU_COMMAND dfu-suffix --vid=0x1fc9 --pid=0x000c --did=0x0 -a _tmp.dfu && dfu-prefix -s 0 -a _tmp.dfu)
+	endif(DFU_PREFIX_NOT_FOUND)
+    set(DFU_ALL "ALL")
+else(NOT DFU_NOT_FOUND)
+	MESSAGE(STATUS "dfu-suffix not found: not building DFU file")
+endif(NOT DFU_NOT_FOUND)
+
+
+
+    

--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -26,6 +26,8 @@
 
 enable_language(C CXX ASM)
 
+include(../dfu-util.cmake)
+
 SET(PATH_HACKRF ../..)
 SET(PATH_HACKRF_FIRMWARE ${PATH_HACKRF}/firmware)
 SET(PATH_HACKRF_FIRMWARE_COMMON ${PATH_HACKRF_FIRMWARE}/common)
@@ -160,11 +162,11 @@ macro(DeclareTargets)
 	)
 
 	add_custom_target(
-		${PROJECT_NAME}.dfu ALL
+		${PROJECT_NAME}.dfu ${DFU_ALL}
 		DEPENDS ${PROJECT_NAME}.bin
 		COMMAND rm -f _tmp.dfu _header.bin
 		COMMAND cp ${PROJECT_NAME}.bin _tmp.dfu
-		COMMAND dfu-suffix --vid=0x1fc9 --pid=0x000c --did=0x0 -s 0 -a _tmp.dfu
+		COMMAND ${DFU_COMMAND}
 		COMMAND python -c \"import os.path\; import struct\; print\('0000000: da ff ' + ' '.join\(map\(lambda s: '%02x' % ord\(s\), struct.pack\('<H', os.path.getsize\('${PROJECT_NAME}.bin'\) / 512 + 1\)\)\) + ' ff ff ff ff'\)\" | xxd -g1 -r > _header.bin
 		COMMAND cat _header.bin _tmp.dfu >${PROJECT_NAME}.dfu
 		COMMAND rm -f _tmp.dfu _header.bin


### PR DESCRIPTION
Fixes issue #117 by allowing either dfu-util 0.7 or dfu-util 0.8 to be used.  If neither is installed, it prints a message that DFU files will not be built and does not build them.  This could be changed to an error if needed.

It's a little bit hacky.