### PR TITLE
libhackrf: Fixed segfault in hackrf_device_list

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -351,7 +351,10 @@ hackrf_device_list_t* ADDCALL hackrf_device_list()
 	hackrf_device_list_t* list = calloc(1, sizeof(*list));
 	if ( list == NULL )
 		return NULL;
-		
+
+	if (list->devicecount == 0)
+		return list;
+
 	list->usb_devicecount = libusb_get_device_list(g_libusb_context, (libusb_device ***)&list->usb_devices);
 	
 	list->serial_numbers = calloc(list->usb_devicecount, sizeof(void *));


### PR DESCRIPTION
If there are no dev ices connected then libusb_get_device_list segfaults. This can be tested with list->devicecount. I think that if this is 0 then it is enough to return the list pointer since devicecount value should be checked by the caller.