### PR TITLE
Fixed missing reset of do_exit, which prevented calls to callback whe…

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1415,6 +1415,7 @@ static int create_transfer_thread(hackrf_device* device,
 	if( device->transfer_thread_started == false )
 	{
 		device->streaming = false;
+		do_exit = false;
 
 		result = prepare_transfers(
 			device, endpoint_address,


### PR DESCRIPTION
…n thread is created once again.

I have identified the issue as in https://github.com/mossmann/hackrf/issues/245
