### PR TITLE
Add WCID descriptors

### DIFF
--- a/firmware/common/usb_standard_request.h
+++ b/firmware/common/usb_standard_request.h
@@ -29,6 +29,11 @@ void usb_set_configuration_changed_cb(
         void (*callback)(usb_device_t* const)
 );
 
+usb_request_status_t usb_vendor_request_read_wcid(
+	usb_endpoint_t* const endpoint,
+    const usb_transfer_stage_t stage
+);
+
 usb_request_status_t usb_standard_request(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage

--- a/firmware/common/usb_type.h
+++ b/firmware/common/usb_type.h
@@ -127,6 +127,9 @@ typedef struct {
 	const uint8_t* const qualifier_descriptor;
 	usb_configuration_t* (*configurations)[];
 	const usb_configuration_t* configuration;
+	uint8_t* wcid_string_descriptor;
+	uint8_t* wcid_feature_descriptor;
+	uint8_t* wcid_extended_properties_descriptor;
 } usb_device_t;
 
 typedef struct usb_endpoint_t usb_endpoint_t;

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -139,6 +139,7 @@ static const usb_request_handler_fn vendor_request_handler[] = {
 	NULL,
 #endif
 	usb_vendor_request_set_freq_explicit,
+	usb_vendor_request_read_wcid,  // USB_WCID_VENDOR_REQ
 };
 
 static const uint32_t vendor_request_handler_count =

--- a/firmware/hackrf_usb/usb_descriptor.c
+++ b/firmware/hackrf_usb/usb_descriptor.c
@@ -58,7 +58,7 @@ uint8_t usb_descriptor_device[] = {
 	USB_WORD(0x0100),		   // bcdDevice
 	0x01,				   // iManufacturer
 	0x02,				   // iProduct
-	0x05,				   // iSerialNumber
+	0x04,				   // iSerialNumber
 	0x02				   // bNumConfigurations
 };
 
@@ -70,7 +70,7 @@ uint8_t usb_descriptor_device_qualifier[] = {
 	0x00,					// bDeviceSubClass
 	0x00,					// bDeviceProtocol
 	64,					// bMaxPacketSize0
-	0x02,					// bNumOtherSpeedConfigurations
+	0x01,					// bNumOtherSpeedConfigurations
 	0x00					// bReserved
 };
 
@@ -148,79 +148,6 @@ uint8_t usb_descriptor_configuration_high_speed[] = {
 	0,									// TERMINATOR
 };
 
-uint8_t usb_descriptor_configuration_cpld_update_full_speed[] = {
-	9,					// bLength
-	USB_DESCRIPTOR_TYPE_CONFIGURATION,	// bDescriptorType
-	USB_WORD(32),				// wTotalLength
-	0x01,					// bNumInterfaces
-	0x02,					// bConfigurationValue
-	0x04,					// iConfiguration
-	0x80,					// bmAttributes: USB-powered
-	250,					// bMaxPower: 500mA
-
-	9,							// bLength
-	USB_DESCRIPTOR_TYPE_INTERFACE,		// bDescriptorType
-	0x00,							// bInterfaceNumber
-	0x00,							// bAlternateSetting
-	0x02,							// bNumEndpoints
-	0xFF,							// bInterfaceClass: vendor-specific
-	0xFF,							// bInterfaceSubClass
-	0xFF,							// bInterfaceProtocol: vendor-specific
-	0x00,							// iInterface
-
-	7,							// bLength
-	USB_DESCRIPTOR_TYPE_ENDPOINT,		// bDescriptorType
-	USB_BULK_IN_EP_ADDR,				// bEndpointAddress
-	0x02,							// bmAttributes: BULK
-	USB_WORD(USB_MAX_PACKET_BULK_FS),	// wMaxPacketSize
-	0x00,							// bInterval: no NAK
-
-	7,							// bLength
-	USB_DESCRIPTOR_TYPE_ENDPOINT,		// bDescriptorType
-	USB_BULK_OUT_EP_ADDR,			// bEndpointAddress
-	0x02,							// bmAttributes: BULK
-	USB_WORD(USB_MAX_PACKET_BULK_FS),	// wMaxPacketSize
-	0x00,							// bInterval: no NAK
-
-	0,									// TERMINATOR
-};
-
-uint8_t usb_descriptor_configuration_cpld_update_high_speed[] = {
-	9,							// bLength
-	USB_DESCRIPTOR_TYPE_CONFIGURATION,	// bDescriptorType
-	USB_WORD(32),						// wTotalLength
-	0x01,							// bNumInterfaces
-	0x02,							// bConfigurationValue
-	0x04,							// iConfiguration
-	0x80,							// bmAttributes: USB-powered
-	250,							// bMaxPower: 500mA
-
-	9,							// bLength
-	USB_DESCRIPTOR_TYPE_INTERFACE,		// bDescriptorType
-	0x00,							// bInterfaceNumber
-	0x00,							// bAlternateSetting
-	0x02,							// bNumEndpoints
-	0xFF,							// bInterfaceClass: vendor-specific
-	0xFF,							// bInterfaceSubClass
-	0xFF,							// bInterfaceProtocol: vendor-specific
-	0x00,							// iInterface
-
-	7,							// bLength
-	USB_DESCRIPTOR_TYPE_ENDPOINT,		// bDescriptorType
-	USB_BULK_IN_EP_ADDR,				// bEndpointAddress
-	0x02,							// bmAttributes: BULK
-	USB_WORD(USB_MAX_PACKET_BULK_HS),	// wMaxPacketSize
-	0x00,							// bInterval: no NAK
-
-	7,								// bLength
-	USB_DESCRIPTOR_TYPE_ENDPOINT,		// bDescriptorType
-	USB_BULK_OUT_EP_ADDR,			// bEndpointAddress
-	0x02,							// bmAttributes: BULK
-	USB_WORD(USB_MAX_PACKET_BULK_HS),	// wMaxPacketSize
-	0x00,							// bInterval: no NAK
-
-	0,									// TERMINATOR
-};
 
 uint8_t usb_descriptor_string_languages[] = {
 	0x04,			    // bLength
@@ -298,7 +225,7 @@ uint8_t usb_descriptor_string_product[] = {
 #endif
 };
 
-uint8_t usb_descriptor_string_config1_description[] = {
+uint8_t usb_descriptor_string_config_description[] = {
 	24,						// bLength
 	USB_DESCRIPTOR_TYPE_STRING,		// bDescriptorType
 	'T', 0x00,
@@ -314,21 +241,6 @@ uint8_t usb_descriptor_string_config1_description[] = {
 	'r', 0x00,
 };
 
-uint8_t usb_descriptor_string_config2_description[] = {
-	24,						// bLength
-	USB_DESCRIPTOR_TYPE_STRING,		// bDescriptorType
-	'C', 0x00,
-	'P', 0x00,
-	'L', 0x00,
-	'D', 0x00,
-	' ', 0x00,
-	'u', 0x00,
-	'p', 0x00,
-	'd', 0x00,
-	'a', 0x00,
-	't', 0x00,
-	'e', 0x00,
-};
 
 uint8_t usb_descriptor_string_serial_number[USB_DESCRIPTOR_STRING_SERIAL_BUF_LEN];
 
@@ -336,8 +248,7 @@ uint8_t* usb_descriptor_strings[] = {
 	usb_descriptor_string_languages,
 	usb_descriptor_string_manufacturer,
 	usb_descriptor_string_product,
-	usb_descriptor_string_config1_description,
-	usb_descriptor_string_config2_description,
+	usb_descriptor_string_config_description,
 	usb_descriptor_string_serial_number,
 	0,		// TERMINATOR
 };

--- a/firmware/hackrf_usb/usb_descriptor.c
+++ b/firmware/hackrf_usb/usb_descriptor.c
@@ -55,7 +55,7 @@ uint8_t usb_descriptor_device[] = {
 	USB_MAX_PACKET0,		   // bMaxPacketSize0
 	USB_WORD(USB_VENDOR_ID),	   // idVendor
 	USB_WORD(USB_PRODUCT_ID),	   // idProduct
-	USB_WORD(0x0100),		   // bcdDevice
+	USB_WORD(0x0101),		   // bcdDevice
 	0x01,				   // iManufacturer
 	0x02,				   // iProduct
 	0x04,				   // iSerialNumber
@@ -251,4 +251,31 @@ uint8_t* usb_descriptor_strings[] = {
 	usb_descriptor_string_config_description,
 	usb_descriptor_string_serial_number,
 	0,		// TERMINATOR
+};
+
+uint8_t wcid_string_descriptor[] = {
+	18,                          // bLength
+	USB_DESCRIPTOR_TYPE_STRING,  // bDescriptorType
+	'M', 0x00,
+	'S', 0x00,
+	'F', 0x00,
+	'T', 0x00,
+	'1', 0x00,
+	'0', 0x00,
+	'0', 0x00,
+	USB_WCID_VENDOR_REQ, // vendor request code for further descriptor
+	0x00
+};
+
+uint8_t wcid_feature_descriptor[] = {
+	0x28, 0x00, 0x00, 0x00,  // bLength
+	USB_WORD(0x0100),        // WCID version
+	USB_WORD(0x0004),        // WICD descriptor index
+	0x01,                    //bNumSections
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00, //Reserved
+	0x00,        //bInterfaceNumber
+	0x01,        //Reserved
+	'W', 'I', 'N', 'U', 'S', 'B', 0x00,0x00, //Compatible ID, padded with zeros
+	0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, //Sub-compatible ID
+	0x00,0x00,0x00,0x00,0x00,0x00            //Reserved
 };

--- a/firmware/hackrf_usb/usb_descriptor.h
+++ b/firmware/hackrf_usb/usb_descriptor.h
@@ -25,8 +25,6 @@ extern uint8_t usb_descriptor_device[];
 extern uint8_t usb_descriptor_device_qualifier[];
 extern uint8_t usb_descriptor_configuration_full_speed[];
 extern uint8_t usb_descriptor_configuration_high_speed[];
-extern uint8_t usb_descriptor_configuration_cpld_update_full_speed[];
-extern uint8_t usb_descriptor_configuration_cpld_update_high_speed[];
 extern uint8_t usb_descriptor_string_languages[];
 extern uint8_t usb_descriptor_string_manufacturer[];
 extern uint8_t usb_descriptor_string_product[];

--- a/firmware/hackrf_usb/usb_descriptor.h
+++ b/firmware/hackrf_usb/usb_descriptor.h
@@ -34,3 +34,7 @@ extern uint8_t usb_descriptor_string_product[];
 extern uint8_t usb_descriptor_string_serial_number[];
 
 extern uint8_t* usb_descriptor_strings[];
+
+#define USB_WCID_VENDOR_REQ 0x19
+extern uint8_t wcid_string_descriptor[];
+extern uint8_t wcid_feature_descriptor[];

--- a/firmware/hackrf_usb/usb_device.c
+++ b/firmware/hackrf_usb/usb_device.c
@@ -51,4 +51,6 @@ usb_device_t usb_device = {
 	.qualifier_descriptor = usb_descriptor_device_qualifier,
 	.configurations = &usb_configurations,
 	.configuration = 0,
+	.wcid_string_descriptor = wcid_string_descriptor,
+	.wcid_feature_descriptor = wcid_feature_descriptor,
 };

--- a/firmware/hackrf_usb/usb_device.c
+++ b/firmware/hackrf_usb/usb_device.c
@@ -38,23 +38,10 @@ usb_configuration_t usb_configuration_full_speed = {
 	.descriptor = usb_descriptor_configuration_full_speed,
 };
 
-usb_configuration_t usb_configuration_cpld_update_full_speed = {
-	.number = 2,
-	.speed = USB_SPEED_FULL,
-	.descriptor = usb_descriptor_configuration_cpld_update_full_speed,
-};
-
-usb_configuration_t usb_configuration_cpld_update_high_speed = {
-	.number = 2,
-	.speed = USB_SPEED_HIGH,
-	.descriptor = usb_descriptor_configuration_cpld_update_high_speed,
-};
 
 usb_configuration_t* usb_configurations[] = {
 	&usb_configuration_high_speed,
 	&usb_configuration_full_speed,
-	&usb_configuration_cpld_update_full_speed,
-	&usb_configuration_cpld_update_high_speed,
 	0,
 };
 


### PR DESCRIPTION
This adds the Windows Compatible ID that allows us to tell Windows hosts that we use the WinUSB driver.  It does not add the extended properties descriptor, as I was unsure of the benefit for HackRF, although I added the ability to set it if desired.

Host software such as SDR# will already have libusb, so this removes the step where users need to install libusb/zadig.