### PR TITLE
hackrf_transfer - cast with uint32_t

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -829,7 +829,7 @@ int main(int argc, char** argv) {
 	// Change the freq and sample rate to correct the crystal clock error.
 	if( crystal_correct ) {
 
-		sample_rate_hz = (uint)((double)sample_rate_hz * (1000000 - crystal_correct_ppm)/1000000+0.5);
+		sample_rate_hz = (uint32_t)((double)sample_rate_hz * (1000000 - crystal_correct_ppm)/1000000+0.5);
 		freq_hz = freq_hz * (1000000 - crystal_correct_ppm)/1000000;
 		
 	}


### PR DESCRIPTION
I'm getting ready for new windows installers, just noticed this.
Real minor casting issue, here is the fix to get master compiling:

The compiler (MSVC 2013) didnt have the uint typedef,
switched to using uint32_t which is the type of sample_rate_hz.