### PR TITLE
Make the 'do_exit' flag static

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -288,7 +288,7 @@ char* u64toa(uint64_t val, t_u64toa* str)
 	return res;
 }
 
-volatile bool do_exit = false;
+static volatile bool do_exit = false;
 
 FILE* fd = NULL;
 volatile uint32_t byte_count = 0;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -117,7 +117,7 @@ static const max2837_ft_t max2837_ft[] = {
 	{ 0        }
 };
 
-volatile bool do_exit = false;
+static volatile bool do_exit = false;
 
 static const uint16_t hackrf_usb_vid = 0x1d50;
 static const uint16_t hackrf_jawbreaker_usb_pid = 0x604b;


### PR DESCRIPTION
Both libhackrf and hackrf_transfer are using boolean flag named
"do_exit" which is not static. This is problematic because the flag is
used for different things. This patch fixes the problem by making the
flag static in both places.
Fixes issue #272 