### PR TITLE
Add rad1o board id to libhackrf

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1606,6 +1606,9 @@ const char* ADDCALL hackrf_board_id_name(enum hackrf_board_id board_id)
 	case BOARD_ID_HACKRF_ONE:
 		return "HackRF One";
 
+	case BOARD_ID_RAD1O:
+		return "rad1o";
+
 	case BOARD_ID_INVALID:
 		return "Invalid Board ID";
 
@@ -1623,6 +1626,9 @@ extern ADDAPI const char* ADDCALL hackrf_usb_board_id_name(enum hackrf_usb_board
 
 	case USB_BOARD_ID_HACKRF_ONE:
 		return "HackRF One";
+
+	case USB_BOARD_ID_RAD1O:
+		return "rad1o";
 
 	case USB_BOARD_ID_INVALID:
 		return "Invalid Board ID";

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -66,6 +66,7 @@ enum hackrf_board_id {
 	BOARD_ID_JELLYBEAN  = 0,
 	BOARD_ID_JAWBREAKER = 1,
 	BOARD_ID_HACKRF_ONE = 2,
+	BOARD_ID_RAD1O = 3,
 	BOARD_ID_INVALID = 0xFF,
 };
 


### PR DESCRIPTION
The rad1o is the badge of the Chaos Communication Camp 2015 (CCCamp15).

The rad1o badge contains a full-featured SDR (software defined radio) half-duplex transceiver, operating in a frequency range of about 50 MHz - 4000 MHz, and is software compatible to the HackRF.

See https://rad1o.badge.events.ccc.de for more information.