### PR TITLE
Replace python one liner with script to build dfu files

### DIFF
--- a/firmware/dfu.py
+++ b/firmware/dfu.py
@@ -1,0 +1,7 @@
+import os.path
+import struct
+
+with open("_header.bin", "wb") as f:
+    x = struct.pack('<H', os.path.getsize('hackrf_usb_dfu.bin') // 512 + 1)
+    y = [0xda, 0xff, x[0], x[1], 0xff, 0xff, 0xff, 0xff]
+    f.write(bytearray(y))

--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -194,9 +194,9 @@ macro(DeclareTargets)
 		COMMAND rm -f _tmp.dfu _header.bin
 		COMMAND cp ${PROJECT_NAME}_dfu.bin _tmp.dfu
 		COMMAND ${DFU_COMMAND}
-		COMMAND python -c \"import os.path\; import struct\; print\('0000000: da ff ' + ' '.join\(map\(lambda s: '%02x' % ord\(s\), struct.pack\('<H', os.path.getsize\('${PROJECT_NAME}_dfu.bin'\) / 512 + 1\)\)\) + ' ff ff ff ff'\)\" | xxd -g1 -r > _header.bin
+		COMMAND python ../../dfu.py
 		COMMAND cat _header.bin _tmp.dfu >${PROJECT_NAME}.dfu
-		COMMAND rm -f _tmp.dfu _header.bin
+		#COMMAND rm -f _tmp.dfu _header.bin
 	)
 
 	add_custom_target(

--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -196,7 +196,7 @@ macro(DeclareTargets)
 		COMMAND ${DFU_COMMAND}
 		COMMAND python ../../dfu.py
 		COMMAND cat _header.bin _tmp.dfu >${PROJECT_NAME}.dfu
-		#COMMAND rm -f _tmp.dfu _header.bin
+		COMMAND rm -f _tmp.dfu _header.bin
 	)
 
 	add_custom_target(


### PR DESCRIPTION
This removes a one line python command and puts it in to a script which supports both python 2 and 3.