### PR TITLE
Add USB API versioning

### DIFF
--- a/firmware/hackrf_usb/usb_descriptor.c
+++ b/firmware/hackrf_usb/usb_descriptor.c
@@ -55,7 +55,7 @@ uint8_t usb_descriptor_device[] = {
 	USB_MAX_PACKET0,		   // bMaxPacketSize0
 	USB_WORD(USB_VENDOR_ID),	   // idVendor
 	USB_WORD(USB_PRODUCT_ID),	   // idProduct
-	USB_WORD(0x0101),		   // bcdDevice
+	USB_WORD(0x0102),		   // bcdDevice
 	0x01,				   // iManufacturer
 	0x02,				   // iProduct
 	0x04,				   // iSerialNumber

--- a/host/hackrf-tools/src/hackrf_info.c
+++ b/host/hackrf-tools/src/hackrf_info.c
@@ -104,11 +104,6 @@ int main(void)
 		printf("Part ID Number: 0x%08x 0x%08x\n", 
 					read_partid_serialno.part_id[0],
 					read_partid_serialno.part_id[1]);
-		printf("Serial Number: 0x%08x 0x%08x 0x%08x 0x%08x\n", 
-					read_partid_serialno.serial_no[0],
-					read_partid_serialno.serial_no[1],
-					read_partid_serialno.serial_no[2],
-					read_partid_serialno.serial_no[3]);
 
 		result = hackrf_get_operacake_boards(device, &operacakes[0]);
 		if ((result != HACKRF_SUCCESS) && (result != HACKRF_ERROR_USB_API_VERSION)) {

--- a/host/hackrf-tools/src/hackrf_info.c
+++ b/host/hackrf-tools/src/hackrf_info.c
@@ -31,6 +31,7 @@ int main(void)
 	int result = HACKRF_SUCCESS;
 	uint8_t board_id = BOARD_ID_INVALID;
 	char version[255 + 1];
+	uint16_t usb_version;
 	read_partid_serialno_t read_partid_serialno;
 	uint8_t operacakes[8];
 	hackrf_device_list_t *list;
@@ -55,10 +56,11 @@ int main(void)
 		if (i > 0)
 			printf("\n");
 			
-		printf("Found HackRF board %d:\n", i);
+		printf("Found HackRF\n");
+		printf("Index: %d\n", i);
 		
 		if (list->serial_numbers[i])
-			printf("USB descriptor string: %s\n", list->serial_numbers[i]);
+			printf("Serial number: %s\n", list->serial_numbers[i]);
 
 		device = NULL;
 		result = hackrf_device_list_open(list, i, &device);
@@ -83,7 +85,15 @@ int main(void)
 					hackrf_error_name(result), result);
 			return EXIT_FAILURE;
 		}
-		printf("Firmware Version: %s\n", version);
+
+		result = hackrf_usb_api_version_read(device, &usb_version);
+		if (result != HACKRF_SUCCESS) {
+			fprintf(stderr, "hackrf_usb_api_version_read() failed: %s (%d)\n",
+					hackrf_error_name(result), result);
+			return EXIT_FAILURE;
+		}
+		printf("Firmware Version: %s (API:%x.%02x)\n", version,
+				(usb_version>>8)&0xFF, usb_version&0xFF);
 
 		result = hackrf_board_partid_serialno_read(device, &read_partid_serialno);	
 		if (result != HACKRF_SUCCESS) {
@@ -101,16 +111,17 @@ int main(void)
 					read_partid_serialno.serial_no[3]);
 
 		result = hackrf_get_operacake_boards(device, &operacakes[0]);
-		if (result != HACKRF_SUCCESS) {
+		if ((result != HACKRF_SUCCESS) && (result != HACKRF_ERROR_USB_API_VERSION)) {
 			fprintf(stderr, "hackrf_get_operacake_boards() failed: %s (%d)\n",
 					hackrf_error_name(result), result);
-			return EXIT_FAILURE;
+				return EXIT_FAILURE;
 		}
-		for(j=0; j<8; j++) {
-			if(operacakes[j] == 0)
-				break;
-			printf("Operacake found, address: 0x%02x\n", operacakes[j]);
-
+		if(result == HACKRF_SUCCESS) {
+			for(j=0; j<8; j++) {
+				if(operacakes[j] == 0)
+					break;
+				printf("Operacake found, address: 0x%02x\n", operacakes[j]);
+			}
 		}
 
 		result = hackrf_close(device);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -448,7 +448,7 @@ int main(int argc, char** argv) {
 	result |= hackrf_set_lna_gain(device, lna_gain);
 	result |= hackrf_start_rx(device, rx_callback, NULL);
 	if (result != HACKRF_SUCCESS) {
-		fprintf(stderr, "hackrf_start_?x() failed: %s (%d)\n", hackrf_error_name(result), result);
+		fprintf(stderr, "hackrf_start_rx() failed: %s (%d)\n", hackrf_error_name(result), result);
 		usage();
 		return EXIT_FAILURE;
 	}
@@ -457,7 +457,6 @@ int main(int argc, char** argv) {
 	if( result != HACKRF_SUCCESS ) {
 		fprintf(stderr, "hackrf_init_sweep() failed: %s (%d)\n",
 			   hackrf_error_name(result), result);
-		usage();
 		return EXIT_FAILURE;
 	}
 

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -961,12 +961,10 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	fprintf(stderr, "call hackrf_set_hw_sync_mode(%d)\n",
-			hw_sync);
+	fprintf(stderr, "call hackrf_set_hw_sync_mode(%d)\n", hw_sync);
 	result = hackrf_set_hw_sync_mode(device, hw_sync ? HW_SYNC_MODE_ON : HW_SYNC_MODE_OFF);
 	if( result != HACKRF_SUCCESS ) {
 		fprintf(stderr, "hackrf_set_hw_sync_mode() failed: %s (%d)\n", hackrf_error_name(result), result);
-		usage();
 		return EXIT_FAILURE;
 	}
 

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -59,6 +59,7 @@ enum hackrf_error {
 	HACKRF_ERROR_STREAMING_THREAD_ERR = -1002,
 	HACKRF_ERROR_STREAMING_STOPPED = -1003,
 	HACKRF_ERROR_STREAMING_EXIT_CALLED = -1004,
+	HACKRF_ERROR_USB_API_VERSION = -1005,
 	HACKRF_ERROR_OTHER = -9999,
 };
 
@@ -170,6 +171,7 @@ extern ADDAPI int ADDCALL hackrf_cpld_write(hackrf_device* device,
 		
 extern ADDAPI int ADDCALL hackrf_board_id_read(hackrf_device* device, uint8_t* value);
 extern ADDAPI int ADDCALL hackrf_version_string_read(hackrf_device* device, char* version, uint8_t length);
+extern ADDAPI int ADDCALL hackrf_usb_api_version_read(hackrf_device* device, uint16_t* version);
 
 extern ADDAPI int ADDCALL hackrf_set_freq(hackrf_device* device, const uint64_t freq_hz);
 extern ADDAPI int ADDCALL hackrf_set_freq_explicit(hackrf_device* device,
@@ -198,9 +200,6 @@ extern ADDAPI int ADDCALL hackrf_set_txvga_gain(hackrf_device* device, uint32_t 
 /* antenna port power control */
 extern ADDAPI int ADDCALL hackrf_set_antenna_enable(hackrf_device* device, const uint8_t value);
 
-/* set hardware sync mode  */
-extern ADDAPI int ADDCALL hackrf_set_hw_sync_mode(hackrf_device* device, const uint8_t value);
-
 extern ADDAPI const char* ADDCALL hackrf_error_name(enum hackrf_error errcode);
 extern ADDAPI const char* ADDCALL hackrf_board_id_name(enum hackrf_board_id board_id);
 extern ADDAPI const char* ADDCALL hackrf_usb_board_id_name(enum hackrf_usb_board_id usb_board_id);
@@ -210,6 +209,12 @@ extern ADDAPI const char* ADDCALL hackrf_filter_path_name(const enum rf_path_fil
 extern ADDAPI uint32_t ADDCALL hackrf_compute_baseband_filter_bw_round_down_lt(const uint32_t bandwidth_hz);
 /* Compute best default value depending on sample rate (auto filter) */
 extern ADDAPI uint32_t ADDCALL hackrf_compute_baseband_filter_bw(const uint32_t bandwidth_hz);
+
+/* All features below require USB API version 0x1002 or higher) */
+
+/* set hardware sync mode  */
+extern ADDAPI int ADDCALL hackrf_set_hw_sync_mode(hackrf_device* device, const uint8_t value);
+
 /* Start scan mode */
 extern ADDAPI int ADDCALL hackrf_init_sweep(hackrf_device* device,
 											uint16_t* frequency_list,


### PR DESCRIPTION
Adding USB API version, based on USB descriptor bcdDevice.

Once a device has been found by libusb the calls to hackrf_usb_api_version_read() and USB_API_REQUIRED() should never fail.

Host tools can decide how to handle the error, for example the error is fatal for hackrf_operacake, hackrf_sweep, and hw_sync mode in hackrf_transfer.  The error is silently ignored in hackrf_info.
