### PR TITLE
Sweep csv

### DIFF
--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -36,7 +36,6 @@
 
 volatile bool start_sweep_mode = false;
 static uint64_t sweep_freq;
-static bool odd = true;
 static uint16_t frequencies[MAX_RANGES * 2];
 static unsigned char data[9 + MAX_RANGES * 2 * sizeof(frequencies[0])];
 static uint16_t num_ranges = 0;
@@ -44,7 +43,6 @@ static uint32_t dwell_blocks = 0;
 static uint32_t step_width = 0;
 static uint32_t offset = 0;
 static enum sweep_style style = LINEAR;
-static uint16_t range = 0;
 
 usb_request_status_t usb_vendor_request_init_sweep(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
@@ -89,6 +87,8 @@ usb_request_status_t usb_vendor_request_init_sweep(
 void sweep_mode(void) {
 	unsigned int blocks_queued = 0;
 	unsigned int phase = 1;
+	bool odd = true;
+	uint16_t range = 0;
 
 	uint8_t *buffer;
 	bool transfer = false;

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -78,7 +78,7 @@ usb_request_status_t usb_vendor_request_init_sweep(
 		for(i=0; i<(num_ranges*2); i++) {
 			frequencies[i] = ((uint16_t)(data[10+i*2]) << 8) + data[9+i*2];
 		}
-		sweep_freq = frequencies[0] * FREQ_GRANULARITY;
+		sweep_freq = (uint64_t)frequencies[0] * FREQ_GRANULARITY;
 		set_freq(sweep_freq + offset);
 		start_sweep_mode = true;
 		usb_transfer_schedule_ack(endpoint->in);
@@ -136,7 +136,7 @@ void sweep_mode(void) {
 			if(INTERLEAVED == style) {
 				if(!odd && ((sweep_freq + step_width) >= ((uint64_t)frequencies[1+range*2] * FREQ_GRANULARITY))) {
 					range = (range + 1) % num_ranges;
-					sweep_freq = frequencies[range*2] * FREQ_GRANULARITY;
+					sweep_freq = (uint64_t)frequencies[range*2] * FREQ_GRANULARITY;
 				} else {
 					if(odd) {
 						sweep_freq += step_width/4;
@@ -148,7 +148,7 @@ void sweep_mode(void) {
 			} else {
 				if((sweep_freq + step_width) >= ((uint64_t)frequencies[1+range*2] * FREQ_GRANULARITY)) {
 					range = (range + 1) % num_ranges;
-					sweep_freq = frequencies[range*2] * FREQ_GRANULARITY;
+					sweep_freq = (uint64_t)frequencies[range*2] * FREQ_GRANULARITY;
 				} else {
 					sweep_freq += step_width;
 				}

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -31,31 +31,55 @@
 #define MIN(x,y)       ((x)<(y)?(x):(y))
 #define MAX(x,y)       ((x)>(y)?(x):(y))
 #define FREQ_GRANULARITY 1000000
-#define MIN_FREQ 1
-#define MAX_FREQ 6000
-#define MAX_FREQ_COUNT 1000
+#define MAX_RANGES 10
 #define THROWAWAY_BUFFERS 2
 
 volatile bool start_sweep_mode = false;
 static uint64_t sweep_freq;
-bool odd = true;
-static uint16_t frequencies[MAX_FREQ_COUNT];
-static uint16_t frequency_count = 0;
+static bool odd = true;
+static uint16_t frequencies[MAX_RANGES * 2];
+static unsigned char data[9 + MAX_RANGES * 2 * sizeof(frequencies[0])];
+static uint16_t num_ranges = 0;
 static uint32_t dwell_blocks = 0;
+static uint32_t step_width = 0;
+static uint32_t offset = 0;
+static enum sweep_style style = LINEAR;
+static uint16_t range = 0;
 
 usb_request_status_t usb_vendor_request_init_sweep(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
-	uint32_t dwell_time;
+	uint32_t num_samples;
+	int i;
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		dwell_time = (endpoint->setup.index << 16) | endpoint->setup.value;
-		dwell_blocks = dwell_time / 0x4000;
-		frequency_count = endpoint->setup.length / sizeof(uint16_t);
-		usb_transfer_schedule_block(endpoint->out, &frequencies,
-									endpoint->setup.length, NULL, NULL);
+		num_samples = (endpoint->setup.index << 16) | endpoint->setup.value;
+		dwell_blocks = num_samples / 0x4000;
+		if(1 > dwell_blocks) {
+			return USB_REQUEST_STATUS_STALL;
+		}
+		num_ranges = (endpoint->setup.length - 9) / (2 * sizeof(frequencies[0]));
+		if((1 > num_ranges) || (MAX_RANGES < num_ranges)) {
+			return USB_REQUEST_STATUS_STALL;
+		}
+		usb_transfer_schedule_block(endpoint->out, &data,
+				endpoint->setup.length, NULL, NULL);
 	} else if (stage == USB_TRANSFER_STAGE_DATA) {
-		sweep_freq = frequencies[0];
-		set_freq(sweep_freq*FREQ_GRANULARITY);
+		step_width = ((uint32_t)(data[3]) << 24) | ((uint32_t)(data[2]) << 16)
+				| ((uint32_t)(data[1]) << 8) | data[0];
+		if(1 > step_width) {
+			return USB_REQUEST_STATUS_STALL;
+		}
+		offset = ((uint32_t)(data[7]) << 24) | ((uint32_t)(data[6]) << 16)
+				| ((uint32_t)(data[5]) << 8) | data[4];
+		style = data[8];
+		if(INTERLEAVED < style) {
+			return USB_REQUEST_STATUS_STALL;
+		}
+		for(i=0; i<(num_ranges*2); i++) {
+			frequencies[i] = ((uint16_t)(data[10+i*2]) << 8) + data[9+i*2];
+		}
+		sweep_freq = frequencies[0] * FREQ_GRANULARITY;
+		set_freq(sweep_freq + offset);
 		start_sweep_mode = true;
 		usb_transfer_schedule_ack(endpoint->in);
 	}
@@ -65,7 +89,6 @@ usb_request_status_t usb_vendor_request_init_sweep(
 void sweep_mode(void) {
 	unsigned int blocks_queued = 0;
 	unsigned int phase = 0;
-	unsigned int ifreq = 0;
 
 	uint8_t *buffer;
 	bool transfer = false;
@@ -88,8 +111,16 @@ void sweep_mode(void) {
 		}
 
 		if (transfer) {
-			*(uint16_t*)buffer = 0x7F7F;
-			*(uint16_t*)(buffer+2) = sweep_freq;
+			*buffer = 0x7f;
+			*(buffer+1) = 0x7f;
+			*(buffer+2) = sweep_freq & 0xff;
+			*(buffer+3) = (sweep_freq >> 8) & 0xff;
+			*(buffer+4) = (sweep_freq >> 16) & 0xff;
+			*(buffer+5) = (sweep_freq >> 24) & 0xff;
+			*(buffer+6) = (sweep_freq >> 32) & 0xff;
+			*(buffer+7) = (sweep_freq >> 40) & 0xff;
+			*(buffer+8) = (sweep_freq >> 48) & 0xff;
+			*(buffer+9) = (sweep_freq >> 56) & 0xff;
 			if (blocks_queued > THROWAWAY_BUFFERS) {
 				usb_transfer_schedule_block(
 					&usb_endpoint_bulk_in,
@@ -102,10 +133,27 @@ void sweep_mode(void) {
 		}
 
 		if ((dwell_blocks + THROWAWAY_BUFFERS) <= blocks_queued) {
-			if(++ifreq >= frequency_count)
-				ifreq = 0;
-			sweep_freq = frequencies[ifreq];
-			set_freq(sweep_freq*FREQ_GRANULARITY);
+			if(INTERLEAVED == style) {
+				if(!odd && ((sweep_freq + step_width) >= ((uint64_t)frequencies[1+range*2] * FREQ_GRANULARITY))) {
+					range = (range + 1) % num_ranges;
+					sweep_freq = frequencies[range*2] * FREQ_GRANULARITY;
+				} else {
+					if(odd) {
+						sweep_freq += step_width/4;
+					} else {
+						sweep_freq += 3*step_width/4;
+					}
+				}
+				odd = !odd;
+			} else {
+				if((sweep_freq + step_width) >= ((uint64_t)frequencies[1+range*2] * FREQ_GRANULARITY)) {
+					range = (range + 1) % num_ranges;
+					sweep_freq = frequencies[range*2] * FREQ_GRANULARITY;
+				} else {
+					sweep_freq += step_width;
+				}
+			}
+			set_freq(sweep_freq + offset);
 			blocks_queued = 0;
 		}
 	}

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -88,7 +88,7 @@ usb_request_status_t usb_vendor_request_init_sweep(
 
 void sweep_mode(void) {
 	unsigned int blocks_queued = 0;
-	unsigned int phase = 0;
+	unsigned int phase = 1;
 
 	uint8_t *buffer;
 	bool transfer = false;

--- a/firmware/hackrf_usb/usb_api_sweep.h
+++ b/firmware/hackrf_usb/usb_api_sweep.h
@@ -38,4 +38,4 @@ usb_request_status_t usb_vendor_request_init_sweep(
 
 void sweep_mode(void);
 
-#endif /* __USB_API_SPCAN_H__ */
+#endif /* __USB_API_SWEEP_H__ */

--- a/firmware/hackrf_usb/usb_api_sweep.h
+++ b/firmware/hackrf_usb/usb_api_sweep.h
@@ -19,14 +19,19 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_SCAN_H__
-#define __USB_API_SCAN_H__
+#ifndef __USB_API_SWEEP_H__
+#define __USB_API_SWEEP_H__
 
 #include <stdbool.h>
 #include <usb_type.h>
 #include <usb_request.h>
 
 extern volatile bool start_sweep_mode;
+
+enum sweep_style {
+	LINEAR = 0,
+	INTERLEAVED = 1,
+};
 
 usb_request_status_t usb_vendor_request_init_sweep(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -173,6 +173,7 @@ bool antenna = false;
 uint32_t antenna_enable;
 
 bool binary_output = false;
+volatile bool sweep_started = false;
 
 int fftSize = 20;
 uint32_t fft_bin_width;
@@ -215,6 +216,14 @@ int rx_callback(hackrf_transfer* transfer) {
 		} else {
 			buf += SAMPLES_PER_BLOCK;
 			break;
+		}
+		if(!sweep_started) {
+			if (frequency == (uint64_t)(FREQ_ONE_MHZ*frequencies[0])) {
+				sweep_started = true;
+			} else {
+				buf += SAMPLES_PER_BLOCK;
+				continue;
+			}
 		}
 		if((FREQ_MAX_MHZ * FREQ_ONE_MHZ) < frequency) {
 			buf += SAMPLES_PER_BLOCK;

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -235,7 +235,7 @@ int rx_callback(hackrf_transfer* transfer) {
 				strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
 				printf("%s, %" PRIu64 ", %" PRIu64 ", %f, %d, ",
 						time_str,
-						(uint64_t)((FREQ_ONE_MHZ*frequency)+1-STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)-STEP_SIZE_IN_HZ*((FFT_SIZE/2)-1)),
 						(uint64_t)((FREQ_ONE_MHZ*frequency)+STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
 						(float)STEP_SIZE_IN_HZ,
 						FFT_SIZE);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -242,16 +242,16 @@ int rx_callback(hackrf_transfer* transfer) {
 				time_now = time(NULL);
 				fft_time = localtime(&time_now);
 				strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
-				printf("%s, %" PRIu64 ", %" PRIu64 ", %.2f, %d, ",
+				printf("%s, %" PRIu64 ", %" PRIu64 ", %.2f, %d",
 						time_str,
 						(uint64_t)((FREQ_ONE_MHZ*frequency)-(DEFAULT_SAMPLE_RATE_HZ/2)),
 						(uint64_t)((FREQ_ONE_MHZ*frequency)+(DEFAULT_SAMPLE_RATE_HZ/2)),
 						(float)STEP_SIZE_IN_HZ,
 						FFT_SIZE);
-				for(i=0; i < (fftSize - 1); i++) {
-					printf("%.2f, ", pwr[i]);
+				for(i=0; i < fftSize; i++) {
+					printf(", %.2f", pwr[i]);
 				}
-				printf("%.2f\n", pwr[fftSize - 1]);
+				printf("\n");
 			}
 		}
 		return 0;

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -276,15 +276,18 @@ int rx_callback(hackrf_transfer* transfer) {
 static void usage() {
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, "\t[-h] # this help\n");
-	fprintf(stderr, "\t[-d serial_number] # Serial number of desired HackRF.\n");
-	fprintf(stderr, "\t[-a amp_enable] # RX RF amplifier 1=Enable, 0=Disable.\n");
-	fprintf(stderr, "\t[-f freq_min:freq_max] # Specify minimum & maximum sweep frequencies (MHz).\n");
-	fprintf(stderr, "\t[-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable.\n");
+	fprintf(stderr, "\t[-d serial_number] # Serial number of desired HackRF\n");
+	fprintf(stderr, "\t[-a amp_enable] # RX RF amplifier 1=Enable, 0=Disable\n");
+	fprintf(stderr, "\t[-f freq_min:freq_max] # minimum and maximum frequencies in MHz\n");
+	fprintf(stderr, "\t[-p antenna_enable] # Antenna port power, 1=Enable, 0=Disable\n");
 	fprintf(stderr, "\t[-l gain_db] # RX LNA (IF) gain, 0-40dB, 8dB steps\n");
 	fprintf(stderr, "\t[-g gain_db] # RX VGA (baseband) gain, 0-62dB, 2dB steps\n");
 	fprintf(stderr, "\t[-n num_samples] # Number of samples per frequency, 16384-4294967296\n");
 	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz\n");
 	fprintf(stderr, "\t[-B] # binary output\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Output fields:\n");
+	fprintf(stderr, "\tdate, time, hz_low, hz_high, hz_bin_width, num_samples, dB, dB, . . .\n");
 }
 
 static hackrf_device* device = NULL;

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -233,10 +233,14 @@ int rx_callback(hackrf_transfer* transfer) {
 				pwr[i] = logPower(fftwOut[i], 1.0f / fftSize);
 			}
 			if(binary_output) {
-				float_freq = frequency;
+				float_freq = frequency + DEFAULT_SAMPLE_RATE_HZ / 4;
 				float_freq /= FREQ_ONE_MHZ;
 				fwrite(&float_freq, sizeof(float), 1, stdout);
-				fwrite(pwr, sizeof(float), fftSize, stdout);
+				fwrite(&pwr[1+(fftSize*5)/8], sizeof(float), fftSize/4, stdout);
+				float_freq = frequency + DEFAULT_SAMPLE_RATE_HZ / 2;
+				float_freq /= FREQ_ONE_MHZ;
+				fwrite(&float_freq, sizeof(float), 1, stdout);
+				fwrite(&pwr[1+fftSize/8], sizeof(float), fftSize/4, stdout);
 			} else {
 				time_now = time(NULL);
 				fft_time = localtime(&time_now);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -215,7 +215,7 @@ int rx_callback(hackrf_transfer* transfer) {
 				buf += SAMPLES_PER_BLOCK;
 				break;
 			}
-			if((FREQ_MAX_HZ*FREQ_ONE_MHZ < frequency)) {
+			if((FREQ_MAX_HZ < frequency)) {
 				buf += SAMPLES_PER_BLOCK;
 				break;
 			}

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -235,7 +235,7 @@ int rx_callback(hackrf_transfer* transfer) {
 				strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
 				printf("%s, %" PRIu64 ", %" PRIu64 ", %f, %d, ",
 						time_str,
-						(uint64_t)((FREQ_ONE_MHZ*frequency)-STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)+1-STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
 						(uint64_t)((FREQ_ONE_MHZ*frequency)+STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
 						(float)STEP_SIZE_IN_HZ,
 						FFT_SIZE);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <fftw3.h>
 #include <math.h>
+#include <inttypes.h>
 
 #define _FILE_OFFSET_BITS 64
 #define BLOCKS_PER_TRANSFER 16
@@ -232,7 +233,12 @@ int rx_callback(hackrf_transfer* transfer) {
 				time_now = time(NULL);
 				fft_time = localtime(&time_now);
 				strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
-				printf("%s, hz_low, hz_high, hz_step, num_samples, ", time_str);
+				printf("%s, %" PRIu64 ", %" PRIu64 ", %f, %d, ",
+						time_str,
+						(uint64_t)((FREQ_ONE_MHZ*frequency)-STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)+STEP_SIZE_IN_HZ*(FFT_SIZE/2)),
+						(float)STEP_SIZE_IN_HZ,
+						FFT_SIZE);
 				for(i=0; i < (fftSize - 1); i++) {
 					printf("%.2f, ", pwr[i]);
 				}

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -201,7 +201,7 @@ int rx_callback(hackrf_transfer* transfer) {
 	 * write output to pipe
 	 */
 	int8_t* buf;
-	uint16_t frequency;
+	uint16_t frequency; /* in MHz */
 	float float_freq;
 	int i, j;
 
@@ -215,7 +215,7 @@ int rx_callback(hackrf_transfer* transfer) {
 				buf += SAMPLES_PER_BLOCK;
 				break;
 			}
-			if((FREQ_MAX_HZ < frequency)) {
+			if(FREQ_MAX_HZ < (FREQ_ONE_MHZ*frequency)) {
 				buf += SAMPLES_PER_BLOCK;
 				break;
 			}

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -230,11 +230,7 @@ int rx_callback(hackrf_transfer* transfer) {
 			buf += fftSize * 2;
 			fftwf_execute(fftwPlan);
 			for (i=0; i < fftSize; i++) {
-				// Start from the middle of the FFTW array and wrap
-				// to rearrange the data
-				//FIXME only works when fftSize = 2**n
-				int k = i ^ (fftSize >> 1);
-				pwr[i] = logPower(fftwOut[k], 1.0f / fftSize);
+				pwr[i] = logPower(fftwOut[i], 1.0f / fftSize);
 			}
 			if(binary_output) {
 				float_freq = frequency;
@@ -251,7 +247,7 @@ int rx_callback(hackrf_transfer* transfer) {
 						(uint64_t)(frequency+DEFAULT_SAMPLE_RATE_HZ/4),
 						(float)fft_bin_width,
 						fftSize);
-				for(i=1+fftSize/8; (1+(fftSize*3)/8) > i; i++) {
+				for(i=1+(fftSize*5)/8; (1+(fftSize*7)/8) > i; i++) {
 					printf(", %.2f", pwr[i]);
 				}
 				printf("\n");
@@ -261,7 +257,7 @@ int rx_callback(hackrf_transfer* transfer) {
 						(uint64_t)(frequency+((DEFAULT_SAMPLE_RATE_HZ*3)/4)),
 						(float)fft_bin_width,
 						fftSize);
-				for(i=1+(fftSize*5)/8; (1+(fftSize*7)/8) > i; i++) {
+				for(i=1+fftSize/8; (1+(fftSize*3)/8) > i; i++) {
 					printf(", %.2f", pwr[i]);
 				}
 				printf("\n");

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -99,8 +99,6 @@ int gettimeofday(struct timeval *tv, void* ignored) {
 
 #define DEFAULT_SAMPLE_COUNT 0x4000
 #define BLOCKS_PER_TRANSFER 16
-#define FFT_BIN_WIDTH_HZ 312500
-#define FFT_SIZE 64
 
 #if defined _WIN32
 	#define sleep(a) Sleep( (a*1000) )
@@ -175,7 +173,8 @@ uint32_t antenna_enable;
 
 bool binary_output = false;
 
-int fftSize;
+int fftSize = 20;
+uint32_t fft_bin_width;
 fftwf_complex *fftwIn = NULL;
 fftwf_complex *fftwOut = NULL;
 fftwf_plan fftwPlan = NULL;
@@ -250,9 +249,9 @@ int rx_callback(hackrf_transfer* transfer) {
 						time_str,
 						(uint64_t)(frequency),
 						(uint64_t)(frequency+DEFAULT_SAMPLE_RATE_HZ/4),
-						(float)FFT_BIN_WIDTH_HZ,
-						FFT_SIZE);
-				for(i=fftSize/8; (fftSize*3)/8 > i; i++) {
+						(float)fft_bin_width,
+						fftSize);
+				for(i=1+fftSize/8; (1+(fftSize*3)/8) > i; i++) {
 					printf(", %.2f", pwr[i]);
 				}
 				printf("\n");
@@ -260,9 +259,9 @@ int rx_callback(hackrf_transfer* transfer) {
 						time_str,
 						(uint64_t)(frequency+(DEFAULT_SAMPLE_RATE_HZ/2)),
 						(uint64_t)(frequency+((DEFAULT_SAMPLE_RATE_HZ*3)/4)),
-						(float)FFT_BIN_WIDTH_HZ,
-						FFT_SIZE);
-				for(i=(fftSize*5)/8; (fftSize*7)/8 > i; i++) {
+						(float)fft_bin_width,
+						fftSize);
+				for(i=1+(fftSize*5)/8; (1+(fftSize*7)/8) > i; i++) {
 					printf(", %.2f", pwr[i]);
 				}
 				printf("\n");
@@ -284,6 +283,7 @@ static void usage() {
 	fprintf(stderr, "\t[-l gain_db] # RX LNA (IF) gain, 0-40dB, 8dB steps\n");
 	fprintf(stderr, "\t[-g gain_db] # RX VGA (baseband) gain, 0-62dB, 2dB steps\n");
 	fprintf(stderr, "\t[-n num_samples] # Number of samples per frequency, 16384-4294967296\n");
+	fprintf(stderr, "\t[-w bin_width] # FFT bin width (frequency resolution) in Hz\n");
 	fprintf(stderr, "\t[-B] # binary output\n");
 }
 
@@ -320,7 +320,7 @@ int main(int argc, char** argv) {
 	uint32_t freq_max = 6000;
 
 
-	while( (opt = getopt(argc, argv, "a:f:p:l:g:d:n:Bh?")) != EOF ) {
+	while( (opt = getopt(argc, argv, "a:f:p:l:g:d:n:w:Bh?")) != EOF ) {
 		result = HACKRF_SUCCESS;
 		switch( opt ) 
 		{
@@ -375,6 +375,11 @@ int main(int argc, char** argv) {
 
 		case 'n':
 			result = parse_u32(optarg, &num_samples);
+			break;
+
+		case 'w':
+			result = parse_u32(optarg, &fft_bin_width);
+			fftSize = DEFAULT_SAMPLE_RATE_HZ / fft_bin_width;
 			break;
 
 		case 'B':
@@ -437,7 +442,27 @@ int main(int argc, char** argv) {
 		num_ranges++;
 	}
 
-	fftSize = FFT_SIZE;
+	if(4 > fftSize) {
+		fprintf(stderr,
+				"argument error: FFT bin width (-w) must be no more than one quarter the sample rate\n");
+		return EXIT_FAILURE;
+	}
+
+	if(65536 < fftSize) {
+		fprintf(stderr,
+				"argument error: FFT bin width (-w) resulted in more than 65536 FFT bins\n");
+		return EXIT_FAILURE;
+	}
+
+	/* In interleaved mode, the FFT bin selection works best if the total
+	 * number of FFT bins is equal to an odd multiple of four.
+	 * (e.g. 4, 12, 20, 28, 36, . . .)
+	 */
+	while((fftSize + 4) % 8) {
+		fftSize++;
+	}
+
+	fft_bin_width = DEFAULT_SAMPLE_RATE_HZ / fftSize;
 	fftwIn = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * fftSize);
 	fftwOut = (fftwf_complex*)fftwf_malloc(sizeof(fftwf_complex) * fftSize);
 	fftwPlan = fftwf_plan_dft_1d(fftSize, fftwIn, fftwOut, FFTW_FORWARD, FFTW_MEASURE);

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -244,11 +244,21 @@ int rx_callback(hackrf_transfer* transfer) {
 				strftime(time_str, 50, "%Y-%m-%d, %H:%M:%S", fft_time);
 				printf("%s, %" PRIu64 ", %" PRIu64 ", %.2f, %d",
 						time_str,
-						(uint64_t)((FREQ_ONE_MHZ*frequency)-(DEFAULT_SAMPLE_RATE_HZ/2)),
-						(uint64_t)((FREQ_ONE_MHZ*frequency)+(DEFAULT_SAMPLE_RATE_HZ/2)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)-((DEFAULT_SAMPLE_RATE_HZ*3)/8)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)-(DEFAULT_SAMPLE_RATE_HZ/8)),
 						(float)STEP_SIZE_IN_HZ,
 						FFT_SIZE);
-				for(i=0; i < fftSize; i++) {
+				for(i=fftSize/8; (fftSize*3)/8 > i; i++) {
+					printf(", %.2f", pwr[i]);
+				}
+				printf("\n");
+				printf("%s, %" PRIu64 ", %" PRIu64 ", %.2f, %d",
+						time_str,
+						(uint64_t)((FREQ_ONE_MHZ*frequency)+(DEFAULT_SAMPLE_RATE_HZ/8)),
+						(uint64_t)((FREQ_ONE_MHZ*frequency)+((DEFAULT_SAMPLE_RATE_HZ*3)/8)),
+						(float)STEP_SIZE_IN_HZ,
+						FFT_SIZE);
+				for(i=(fftSize*5)/8; (fftSize*7)/8 > i; i++) {
 					printf(", %.2f", pwr[i]);
 				}
 				printf("\n");

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -215,7 +215,7 @@ int rx_callback(hackrf_transfer* transfer) {
 					| ((uint64_t)(ubuf[3]) << 8) | ubuf[2];
 		} else {
 			buf += SAMPLES_PER_BLOCK;
-			break;
+			continue;
 		}
 		if(!sweep_started) {
 			if (frequency == (uint64_t)(FREQ_ONE_MHZ*frequencies[0])) {
@@ -227,7 +227,7 @@ int rx_callback(hackrf_transfer* transfer) {
 		}
 		if((FREQ_MAX_MHZ * FREQ_ONE_MHZ) < frequency) {
 			buf += SAMPLES_PER_BLOCK;
-			break;
+			continue;
 		}
 		/* copy to fftwIn as floats */
 		buf += SAMPLES_PER_BLOCK - (fftSize * 2);

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -807,9 +807,6 @@ int main(int argc, char** argv) {
 
 	if( baseband_filter_bw )
 	{
-		/* Compute nearest freq for bw filter */
-		baseband_filter_bw_hz = hackrf_compute_baseband_filter_bw(baseband_filter_bw_hz);
-
 		if (baseband_filter_bw_hz > BASEBAND_FILTER_BW_MAX) {
 			fprintf(stderr, "argument error: baseband_filter_bw_hz must be less or equal to %u Hz/%.03f MHz\n",
 					BASEBAND_FILTER_BW_MAX, (float)(BASEBAND_FILTER_BW_MAX/FREQ_ONE_MHZ));
@@ -823,6 +820,9 @@ int main(int argc, char** argv) {
 			usage();
 			return EXIT_FAILURE;
 		}
+
+		/* Compute nearest freq for bw filter */
+		baseband_filter_bw_hz = hackrf_compute_baseband_filter_bw(baseband_filter_bw_hz);
 	}
 
 	if(requested_mode_count > 1) {

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -47,6 +47,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
 #endif
 
+#define SAMPLES_PER_BLOCK 16384
+#define MAX_SWEEP_RANGES 10
+
 enum hackrf_error {
 	HACKRF_SUCCESS = 0,
 	HACKRF_TRUE = 1,
@@ -93,6 +96,11 @@ enum operacake_ports {
 	OPERACAKE_PB2 = 5,
 	OPERACAKE_PB3 = 6,
 	OPERACAKE_PB4 = 7,
+};
+
+enum sweep_style {
+	LINEAR = 0,
+	INTERLEAVED = 1,
 };
 
 typedef struct hackrf_device hackrf_device;
@@ -218,10 +226,11 @@ extern ADDAPI uint32_t ADDCALL hackrf_compute_baseband_filter_bw(const uint32_t 
 /* set hardware sync mode  */
 extern ADDAPI int ADDCALL hackrf_set_hw_sync_mode(hackrf_device* device, const uint8_t value);
 
-/* Start scan mode */
+/* Start sweep mode */
 extern ADDAPI int ADDCALL hackrf_init_sweep(hackrf_device* device,
-											uint16_t* frequency_list,
-											int length, uint32_t dwell_time);
+		const uint16_t* frequency_list, const int num_ranges,
+		const uint32_t num_samples, const uint32_t step_width,
+		const uint32_t offset, const enum sweep_style style);
 
 /* Operacake functions */
 extern ADDAPI int ADDCALL hackrf_get_operacake_boards(hackrf_device* device, uint8_t* boards);


### PR DESCRIPTION
I added several features to hackrf_sweep and the sweep capability in firmware.  Most notably the default output format of hackrf_sweep is now a text csv format similar to the output of rtl_power.  The previous binary output format can be enabled with the -B option.