### PR TITLE
IFFT

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -581,12 +581,6 @@ int main(int argc, char** argv) {
 
 	result = hackrf_set_vga_gain(device, vga_gain);
 	result |= hackrf_set_lna_gain(device, lna_gain);
-	result |= hackrf_start_rx(device, rx_callback, NULL);
-	if (result != HACKRF_SUCCESS) {
-		fprintf(stderr, "hackrf_start_rx() failed: %s (%d)\n", hackrf_error_name(result), result);
-		usage();
-		return EXIT_FAILURE;
-	}
 
 	/*
 	 * For each range, plan a whole number of tuning steps of a certain
@@ -599,6 +593,13 @@ int main(int argc, char** argv) {
 		frequencies[2*i+1] = frequencies[2*i] + step_count * TUNE_STEP;
 		fprintf(stderr, "Sweeping from %u MHz to %u MHz\n",
 				frequencies[2*i], frequencies[2*i+1]);
+	}
+
+	result |= hackrf_start_rx(device, rx_callback, NULL);
+	if (result != HACKRF_SUCCESS) {
+		fprintf(stderr, "hackrf_start_rx() failed: %s (%d)\n", hackrf_error_name(result), result);
+		usage();
+		return EXIT_FAILURE;
 	}
 
 	result = hackrf_init_sweep(device, frequencies, num_ranges, num_samples * 2,

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -235,8 +235,8 @@ int rx_callback(hackrf_transfer* transfer) {
 				for(i=0; i < ifft_bins; i++) {
 					ifftwOut[i][0] *= 1.0f / ifft_bins;
 					ifftwOut[i][1] *= 1.0f / ifft_bins;
-					fwrite(&ifftwOut[i][0], sizeof(float), 1, stdout);
-					fwrite(&ifftwOut[i][1], sizeof(float), 1, stdout);
+					fwrite(&ifftwOut[i][0], sizeof(float), 1, fd);
+					fwrite(&ifftwOut[i][1], sizeof(float), 1, fd);
 				}
 				if(one_shot) {
 					do_exit = true;
@@ -281,19 +281,19 @@ int rx_callback(hackrf_transfer* transfer) {
 			record_length = 2 * sizeof(band_edge)
 					+ (fftSize/4) * sizeof(float);
 
-			fwrite(&record_length, sizeof(record_length), 1, stdout);
+			fwrite(&record_length, sizeof(record_length), 1, fd);
 			band_edge = frequency;
-			fwrite(&band_edge, sizeof(band_edge), 1, stdout);
+			fwrite(&band_edge, sizeof(band_edge), 1, fd);
 			band_edge = frequency + DEFAULT_SAMPLE_RATE_HZ / 4;
-			fwrite(&band_edge, sizeof(band_edge), 1, stdout);
-			fwrite(&pwr[1+(fftSize*5)/8], sizeof(float), fftSize/4, stdout);
+			fwrite(&band_edge, sizeof(band_edge), 1, fd);
+			fwrite(&pwr[1+(fftSize*5)/8], sizeof(float), fftSize/4, fd);
 
-			fwrite(&record_length, sizeof(record_length), 1, stdout);
+			fwrite(&record_length, sizeof(record_length), 1, fd);
 			band_edge = frequency + DEFAULT_SAMPLE_RATE_HZ / 2;
-			fwrite(&band_edge, sizeof(band_edge), 1, stdout);
+			fwrite(&band_edge, sizeof(band_edge), 1, fd);
 			band_edge = frequency + (DEFAULT_SAMPLE_RATE_HZ * 3) / 4;
-			fwrite(&band_edge, sizeof(band_edge), 1, stdout);
-			fwrite(&pwr[1+fftSize/8], sizeof(float), fftSize/4, stdout);
+			fwrite(&band_edge, sizeof(band_edge), 1, fd);
+			fwrite(&pwr[1+fftSize/8], sizeof(float), fftSize/4, fd);
 		} else if(ifft_output) {
 			for(i = 0; (fftSize / 4) > i; i++) {
 				ifftwIn[ifft_idx + i][0] = fftwOut[i + 1 + (fftSize*5)/8][0];


### PR DESCRIPTION
 hackrf_sweep: Added experimental Inverse FFT binary output mode.

In this mode, FFT output bins from multiple hops are stitched together into a single set of bins per sweep.  Each sweep is then processed with an inverse FFT to simulate a time domain signal at a sample rate equal to the sweep bandwidth. This wideband time domain signal is sent to the output as complex floats and can be piped to or viewed with tools such as fosphor or inspectrum.  The output signal is discontinuous, so the time axis (e.g. in inspectrum) will be incorrect.