### PR TITLE
Opera glasses: allow user specified ranges for operacake ports

### DIFF
--- a/firmware/common/operacake.h
+++ b/firmware/common/operacake.h
@@ -40,11 +40,15 @@ extern "C"
 #define OPERACAKE_PB3 6
 #define OPERACAKE_PB4 7
 
+#define MAX_OPERACAKE_RANGES 8
+
 /* Up to 8 Operacake boards can be used with one HackRF */
 extern uint8_t operacake_boards[8];
 
 uint8_t operacake_init(void);
 uint8_t operacake_set_ports(uint8_t address, uint8_t PA, uint8_t PB);
+uint8_t operacake_add_range(uint16_t freq_min, uint16_t freq_max, uint8_t port);
+uint8_t operacake_set_range(uint32_t freq_mhz);
 
 #ifdef __cplusplus
 }

--- a/firmware/common/tuning.c
+++ b/firmware/common/tuning.c
@@ -28,6 +28,7 @@
 #include <mixer.h>
 #include <max2837.h>
 #include <sgpio.h>
+#include <operacake.h>
 
 #define FREQ_ONE_MHZ     (1000*1000)
 
@@ -115,6 +116,7 @@ bool set_freq(const uint64_t freq)
 	if( success ) {
 		freq_cache = freq;
 		hackrf_ui_setFrequency(freq);
+		operacake_set_range(freq_mhz);
 	}
 	return success;
 }

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -88,7 +88,8 @@ static const usb_request_handler_fn vendor_request_handler[] = {
 	usb_vendor_request_operacake_get_boards,
 	usb_vendor_request_operacake_set_ports,
 	usb_vendor_request_set_hw_sync_mode,
-	usb_vendor_request_reset
+	usb_vendor_request_reset,
+	usb_vendor_request_operacake_set_ranges
 };
 
 static const uint32_t vendor_request_handler_count =

--- a/firmware/hackrf_usb/usb_api_operacake.h
+++ b/firmware/hackrf_usb/usb_api_operacake.h
@@ -31,4 +31,7 @@ usb_request_status_t  usb_vendor_request_operacake_get_boards(
 usb_request_status_t usb_vendor_request_operacake_set_ports(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 
+usb_request_status_t usb_vendor_request_operacake_set_ranges(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+
 #endif /* end of include guard: __USB_API_OPERACAKE_H__ */

--- a/firmware/hackrf_usb/usb_descriptor.c
+++ b/firmware/hackrf_usb/usb_descriptor.c
@@ -36,6 +36,8 @@
 #define USB_PRODUCT_ID			(0xFFFF)
 #endif
 
+#define USB_API_VERSION			(0x0103)
+
 #define USB_WORD(x)	(x & 0xFF), ((x >> 8) & 0xFF)
 
 #define USB_MAX_PACKET0     	(64)
@@ -57,7 +59,7 @@ uint8_t usb_descriptor_device[] = {
 	USB_MAX_PACKET0,		   // bMaxPacketSize0
 	USB_WORD(USB_VENDOR_ID),	   // idVendor
 	USB_WORD(USB_PRODUCT_ID),	   // idProduct
-	USB_WORD(0x0102),		   // bcdDevice
+	USB_WORD(USB_API_VERSION),	// bcdDevice
 	0x01,				   // iManufacturer
 	0x02,				   // iProduct
 	0x04,				   // iSerialNumber

--- a/host/hackrf-tools/src/CMakeLists.txt
+++ b/host/hackrf-tools/src/CMakeLists.txt
@@ -32,6 +32,7 @@ SET(TOOLS
 	hackrf_info
 	hackrf_debug
 	hackrf_sweep
+	hackrf_operacake
 )
 
 if(MSVC)

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -78,6 +78,7 @@ typedef enum {
 	HACKRF_VENDOR_REQUEST_OPERACAKE_SET_PORTS = 28,
 	HACKRF_VENDOR_REQUEST_SET_HW_SYNC_MODE = 29,
 	HACKRF_VENDOR_REQUEST_RESET = 30,
+	HACKRF_VENDOR_REQUEST_OPERACAKE_SET_RANGES = 31,
 } hackrf_vendor_request;
 
 #define USB_CONFIG_STANDARD 0x1
@@ -1967,6 +1968,29 @@ int ADDCALL hackrf_reset(hackrf_device* device) {
 	}
 }
 
+int ADDCALL hackrf_set_operacake_ranges(hackrf_device* device, uint8_t* ranges, uint8_t len_ranges)
+{
+	USB_API_REQUIRED(device, 0x0103)
+	int result;
+
+	result = libusb_control_transfer(
+		device->usb_device,
+		LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
+		HACKRF_VENDOR_REQUEST_OPERACAKE_SET_RANGES,
+		0,
+		0,
+		ranges,
+		len_ranges,
+		0
+	);
+
+	if (result < len_ranges) {
+		last_libusb_error = result;
+		return HACKRF_ERROR_LIBUSB;
+	} else {
+		return HACKRF_SUCCESS;
+	}
+}
 #ifdef __cplusplus
 } // __cplusplus defined.
 #endif

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -242,6 +242,10 @@ extern ADDAPI int ADDCALL hackrf_set_operacake_ports(hackrf_device* device,
 
 extern ADDAPI int ADDCALL hackrf_reset(hackrf_device* device);
 
+extern ADDAPI int ADDCALL hackrf_set_operacake_ranges(hackrf_device* device,
+                                                      uint8_t* ranges,
+                                                      uint8_t num_ranges);
+
 #ifdef __cplusplus
 } // __cplusplus defined.
 #endif


### PR DESCRIPTION
 - HackRF switches antenna when tuning
 - ports specified using hackrf_operacake cmdline tool
 hackrf_operacake -f 2350:2800:0 -f 0:400:1 -f 400:700:2 -f 700:6000:3