### PR TITLE
Firmware compatibility check

### DIFF
--- a/firmware/hackrf_usb/usb_descriptor.c
+++ b/firmware/hackrf_usb/usb_descriptor.c
@@ -217,6 +217,14 @@ uint8_t usb_descriptor_string_product[] = {
 	'k', 0x00,
 	'e', 0x00,
 	'r', 0x00,
+#elif RAD1O
+	12,						// bLength
+	USB_DESCRIPTOR_TYPE_STRING,		// bDescriptorType
+	'r', 0x00,
+	'a', 0x00,
+	'd', 0x00,
+	'1', 0x00,
+	'o', 0x00,
 #else
 	14,						// bLength
 	USB_DESCRIPTOR_TYPE_STRING,		// bDescriptorType

--- a/host/hackrf-tools/src/hackrf_spiflash.c
+++ b/host/hackrf-tools/src/hackrf_spiflash.c
@@ -59,6 +59,11 @@ static struct option long_options[] = {
 	{ 0, 0, 0, 0 },
 };
 
+/* Check for USB product string descriptor text in firmware file
+ * It should match the appropriate one for the BOARD_ID
+ * If you're already running firmware that reports the wrong ID
+ * I can't help you, but you can use the -i optionto ignore (or DFU)
+ */
 int compatibility_check(uint8_t* data, int length, hackrf_device* device)
 {
 	int str_len, i,j;
@@ -77,18 +82,16 @@ int compatibility_check(uint8_t* data, int length, hackrf_device* device)
 		str_len = 10;
 		break;
 	case BOARD_ID_RAD1O:
-		//This is somewhat problematic,
-		// it's a substring of the others
-		dev_str =  "HackRF";
-		str_len = 6;
+		dev_str =  "rad1o";
+		str_len = 5;
 		break;
 	default:
 		printf("Unknown Board ID");
 		return 1;
 	}
+	// Search for dev_str in uint8_t array of bytes that we're flashing
 	for(i=0; i<length-str_len; i++){
 		if(data[i] == dev_str[0]) {
-			// Test rest of string
 			match = true;
 			for(j=1; j<str_len; j++) {
 				if((data[i+j*2] != dev_str[j]) ||


### PR DESCRIPTION
I've added a check for the USB product string descriptor in the .bin file that `hackrf_spiflash` is writing.  It reads the board ID from the device and checks for the appropriate string in the binary firmware file.

I'm sure there are better / more reliable ways to detect this, but this seems to be relatively robust.

It reads the board ID, not the string from the board, so we can always change the board name in the future without breaking things.  If you're currently running a firmware that reports the incorrect board ID, then it probably isn't booting.

You canalwaysget around this check with `hackrf_spiflash -i` or DFUmode.