### PR TITLE
Fixed a time_stamp bug in rx_callback()

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -252,8 +252,8 @@ int rx_callback(hackrf_transfer* transfer) {
 					(uint64_t)(num_samples + THROWAWAY_BLOCKS * SAMPLES_PER_BLOCK)
 					* j * FREQ_ONE_MHZ / DEFAULT_SAMPLE_RATE_HZ;
 			if(999999 < time_stamp.tv_usec) {
-				time_stamp.tv_usec = time_stamp.tv_usec % 1000000;
 				time_stamp.tv_sec += time_stamp.tv_usec / 1000000;
+				time_stamp.tv_usec = time_stamp.tv_usec % 1000000;
 			}
 		}
 		if(do_exit) {


### PR DESCRIPTION
time_stamp.tv_usec was sent through modulo before time_stamp.tv_sec was updated