### PR TITLE
Open device counting: increment when opening a device

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -348,7 +348,6 @@ extern "C"
 int ADDCALL hackrf_init(void)
 {
 	int libusb_error;
-	open_devices++;
 	if (g_libusb_context != NULL) {
 		return HACKRF_SUCCESS;
 	}
@@ -357,7 +356,6 @@ int ADDCALL hackrf_init(void)
 	if( libusb_error != 0 )
 	{
 		last_libusb_error = libusb_error;
-		open_devices--;
 		return HACKRF_ERROR_LIBUSB;
 	} else {
 		return HACKRF_SUCCESS;
@@ -582,6 +580,7 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 	}
 
 	*device = lib_device;
+	open_devices++;
 
 	return HACKRF_SUCCESS;
 }


### PR DESCRIPTION
Previously it incremented when the library was initialised, this worked
for GNU Radio flowgraphs, but broke elsewhere