### PR TITLE
Remove Windows build warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,6 @@ build_script:
     -DPKG_CONFIG_EXECUTABLE="C:\pkg-config\bin\pkg-config.exe" \
     -DFFTW_INCLUDES=C:\fftw \
     -DFFTW_LIBRARIES=C:\fftw\libfftw3f-3.lib \
-    -D_CRT_NONSTDC_NO_DEPRECATE \
+    -D_CRT_NONSTDC_NO_DEPRECATE=1 \
     ..
   - msbuild HackRF.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,5 @@ build_script:
     -DPKG_CONFIG_EXECUTABLE="C:\pkg-config\bin\pkg-config.exe" \
     -DFFTW_INCLUDES=C:\fftw \
     -DFFTW_LIBRARIES=C:\fftw\libfftw3f-3.lib \
-    -D_CRT_NONSTDC_NO_DEPRECATE=1 \
     ..
   - msbuild HackRF.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,6 @@ build_script:
     -DPKG_CONFIG_EXECUTABLE="C:\pkg-config\bin\pkg-config.exe" \
     -DFFTW_INCLUDES=C:\fftw \
     -DFFTW_LIBRARIES=C:\fftw\libfftw3f-3.lib \
+    -D_CRT_NONSTDC_NO_DEPRECATE \
     ..
   - msbuild HackRF.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"

--- a/host/hackrf-tools/src/hackrf_clock.c
+++ b/host/hackrf-tools/src/hackrf_clock.c
@@ -35,7 +35,7 @@ typedef int bool;
 #define CLOCK_UNDEFINED 0xFF
 #define REGISTER_INVALID 32767
 
-int parse_int(char* s, uint16_t* const value) {
+int parse_int(char* s, uint8_t* const value) {
 	uint_fast8_t base = 10;
 	char* s_end;
 	long long_value;
@@ -55,7 +55,7 @@ int parse_int(char* s, uint16_t* const value) {
 	s_end = s;
 	long_value = strtol(s, &s_end, base);
 	if( (s != s_end) && (*s_end == 0) ) {
-		*value = (uint16_t)long_value;
+		*value = (uint8_t)long_value;
 		return HACKRF_SUCCESS;
 	} else {
 		return HACKRF_ERROR_INVALID_PARAM;
@@ -101,7 +101,7 @@ int si5351c_write_register(
 #define SI5351C_CLK_SRC_MULTISYNTH_0_4  2
 #define SI5351C_CLK_SRC_MULTISYNTH_SELF 3
 
-void print_clk_control(uint8_t clk_ctrl) {
+void print_clk_control(uint16_t clk_ctrl) {
 	uint8_t clk_src, clk_pwr;
 	printf("\tclock control = ");
 	if(clk_ctrl & SI5351C_CLK_POWERDOWN)
@@ -249,9 +249,9 @@ int main(int argc, char** argv) {
 	hackrf_device* device = NULL;
 	int opt, option_index = 0;
 	bool read = false;
-	uint16_t clock = CLOCK_UNDEFINED;
+	uint8_t clock = CLOCK_UNDEFINED;
 	bool clkout = false;
-	uint16_t clkout_enable;
+	uint8_t clkout_enable;
 	const char* serial_number = NULL;
 
 	int result = hackrf_init();

--- a/host/hackrf-tools/src/hackrf_debug.c
+++ b/host/hackrf-tools/src/hackrf_debug.c
@@ -157,7 +157,7 @@ int si5351c_write_register(
 #define SI5351C_CLK_SRC_MULTISYNTH_0_4  2
 #define SI5351C_CLK_SRC_MULTISYNTH_SELF 3
 
-void print_clk_control(uint8_t clk_ctrl) {
+void print_clk_control(uint16_t clk_ctrl) {
 	uint8_t clk_src, clk_pwr;
 	printf("\tclock control = \n");
 	if(clk_ctrl & SI5351C_CLK_POWERDOWN)

--- a/host/hackrf-tools/src/hackrf_operacake.c
+++ b/host/hackrf-tools/src/hackrf_operacake.c
@@ -74,7 +74,7 @@ int parse_uint16(char* const s, uint16_t* const value) {
 
 int parse_u16_range(char* s, hackrf_oc_range* range) {
 	int result = 0;
-	uint16_t port = 0;
+	uint16_t tmp_port, port = 0;
 
 	char *sep = strchr(s, ':');
 	if (!sep)
@@ -97,7 +97,7 @@ int parse_u16_range(char* s, hackrf_oc_range* range) {
 	if(sep2[0] == 'A' || sep2[0] == 'B') {
 		// The port was specified as a side and number eg. A1 or B3
 		if(sep2[1] > 0x30 && sep2[1] < 0x35) {
-			uint16_t tmp_port = sep2[1] - 0x30;
+			tmp_port = sep2[1] - 0x30;
 			if(tmp_port >= 5 || tmp_port <= 0)
 				return HACKRF_ERROR_INVALID_PARAM;
 
@@ -108,7 +108,7 @@ int parse_u16_range(char* s, hackrf_oc_range* range) {
 			} else {
 				// If B was specfied just add 4-1 ports
 				// B1=4, B2=5, B3=6, B4=7
-				port =  (uint16_t) tmp_port+3;
+				port = (uint16_t) tmp_port+3;
 			}
 			//printf("Setting port %c%c to port %d\n", sep2[0], sep2[1], (uint16_t)port);
 		}
@@ -117,7 +117,7 @@ int parse_u16_range(char* s, hackrf_oc_range* range) {
 		if (result != HACKRF_SUCCESS)
 			return result;
 	}
-	range->port = port;
+	range->port = port & 0xFF;
 
 	return HACKRF_SUCCESS;
 }
@@ -248,9 +248,9 @@ int main(int argc, char** argv) {
 		for(i=0; i<range_idx; i++) {
 			ptr = 5*i;
 			range_bytes[ptr] = ranges[i].freq_min >> 8;
-			range_bytes[ptr+1] = ranges[i].freq_min;
+			range_bytes[ptr+1] = ranges[i].freq_min & 0xFF;
 			range_bytes[ptr+2] = ranges[i].freq_max >> 8;
-			range_bytes[ptr+3] = ranges[i].freq_max;
+			range_bytes[ptr+3] = ranges[i].freq_max & 0xFF;
 			range_bytes[ptr+4] = ranges[i].port;
 		}
 

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -564,7 +564,7 @@ int main(int argc, char** argv) {
 	pwr = (float*)fftwf_malloc(sizeof(float) * fftSize);
 	window = (float*)fftwf_malloc(sizeof(float) * fftSize);
 	for (i = 0; i < fftSize; i++) {
-		window[i] = 0.5f * (1.0f - cos(2 * M_PI * i / (fftSize - 1)));
+		window[i] = (float) (0.5f * (1.0f - cos(2 * M_PI * i / (fftSize - 1))));
 	}
 
 	result = hackrf_init();
@@ -640,7 +640,7 @@ int main(int argc, char** argv) {
 	for(i = 0; i < num_ranges; i++) {
 		step_count = 1 + (frequencies[2*i+1] - frequencies[2*i] - 1)
 				/ TUNE_STEP;
-		frequencies[2*i+1] = frequencies[2*i] + step_count * TUNE_STEP;
+		frequencies[2*i+1] = (uint16_t) (frequencies[2*i] + step_count * TUNE_STEP);
 		fprintf(stderr, "Sweeping from %u MHz to %u MHz\n",
 				frequencies[2*i], frequencies[2*i+1]);
 	}

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -198,7 +198,7 @@ float logPower(fftwf_complex in, float scale)
 	float re = in[0] * scale;
 	float im = in[1] * scale;
 	float magsq = re * re + im * im;
-	return log2f(magsq) * 10.0f / log2(10.0f);
+	return (float) (log2(magsq) * 10.0f / log2(10.0f));
 }
 
 int rx_callback(hackrf_transfer* transfer) {
@@ -296,7 +296,7 @@ int rx_callback(hackrf_transfer* transfer) {
 			fwrite(&band_edge, sizeof(band_edge), 1, fd);
 			fwrite(&pwr[1+fftSize/8], sizeof(float), fftSize/4, fd);
 		} else if(ifft_output) {
-			ifft_idx = round((frequency - (uint64_t)(FREQ_ONE_MHZ*frequencies[0]))
+			ifft_idx = (uint32_t) round((frequency - (uint64_t)(FREQ_ONE_MHZ*frequencies[0]))
 					/ fft_bin_width);
 			ifft_idx = (ifft_idx + ifft_bins/2) % ifft_bins;
 			for(i = 0; (fftSize / 4) > i; i++) {

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -641,12 +641,7 @@ int main(int argc, char** argv) {
 			break;
 
 		case 's':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			sample_rate_hz = f_hz;
+			result = parse_u32(optarg, &sample_rate_hz);
 			sample_rate = true;
 			break;
 
@@ -657,12 +652,7 @@ int main(int argc, char** argv) {
 			break;
 
 		case 'b':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			baseband_filter_bw_hz = f_hz;
+			result = parse_u32(optarg, &baseband_filter_bw_hz);
 			baseband_filter_bw = true;
 			break;
 

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -748,7 +748,7 @@ int main(int argc, char** argv) {
 			freq_hz = if_freq_hz;
 			break;
 		case RF_PATH_FILTER_LOW_PASS:
-			freq_hz = (int64_t) labs(if_freq_hz - lo_freq_hz);
+			freq_hz = (int64_t) labs((long int) (if_freq_hz - lo_freq_hz));
 			break;
 		case RF_PATH_FILTER_HIGH_PASS:
 			freq_hz = if_freq_hz + lo_freq_hz;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -254,6 +254,22 @@ int parse_u32(char* s, uint32_t* const value) {
 	}
 }
 
+/* Parse frequencies as doubles to take advantage of notation parsing */
+int parse_frequency_i64(char* optarg, char* endptr, int64_t* value) {
+	*value = (int64_t) strtod(optarg, &endptr);
+	if (optarg == endptr) {
+		return HACKRF_ERROR_INVALID_PARAM;
+	}
+	return HACKRF_SUCCESS;
+}
+
+int parse_frequency_u32(char* optarg, char* endptr, uint32_t* value) {
+	*value = (uint32_t) strtod(optarg, &endptr);
+	if (optarg == endptr) {
+		return HACKRF_ERROR_INVALID_PARAM;
+	}
+	return HACKRF_SUCCESS;
+}
 
 static char *stringrev(char *str)
 {
@@ -537,8 +553,7 @@ int main(int argc, char** argv) {
 	char date_time[DATE_TIME_MAX_LEN];
 	const char* path = NULL;
 	const char* serial_number = NULL;
-	char* endptr;
-	double f_hz;
+	char* endptr = NULL;
 	int result;
 	time_t rawtime;
 	struct tm * timeinfo;
@@ -584,32 +599,17 @@ int main(int argc, char** argv) {
 			break;
 
 		case 'f':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			freq_hz = f_hz;
+			result = parse_frequency_i64(optarg, endptr, &freq_hz);
 			automatic_tuning = true;
 			break;
 
 		case 'i':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			if_freq_hz = f_hz;
+			result = parse_frequency_i64(optarg, endptr, &if_freq_hz);
 			if_freq = true;
 			break;
 
 		case 'o':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			lo_freq_hz = f_hz;
+			result = parse_frequency_i64(optarg, endptr, &lo_freq_hz);
 			lo_freq = true;
 			break;
 
@@ -641,12 +641,7 @@ int main(int argc, char** argv) {
 			break;
 
 		case 's':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			sample_rate_hz = f_hz;
+			result = parse_frequency_u32(optarg, endptr, &sample_rate_hz);
 			sample_rate = true;
 			break;
 
@@ -657,12 +652,7 @@ int main(int argc, char** argv) {
 			break;
 
 		case 'b':
-			f_hz = strtod(optarg, &endptr);
-			if (optarg == endptr) {
-				result = HACKRF_ERROR_INVALID_PARAM;
-				break;
-			}
-			baseband_filter_bw_hz = f_hz;
+			result = parse_frequency_u32(optarg, endptr, &baseband_filter_bw_hz);
 			baseband_filter_bw = true;
 			break;
 
@@ -758,7 +748,7 @@ int main(int argc, char** argv) {
 			freq_hz = if_freq_hz;
 			break;
 		case RF_PATH_FILTER_LOW_PASS:
-			freq_hz = labs(if_freq_hz - lo_freq_hz);
+			freq_hz = labs((long int) if_freq_hz - lo_freq_hz);
 			break;
 		case RF_PATH_FILTER_HIGH_PASS:
 			freq_hz = if_freq_hz + lo_freq_hz;

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -641,7 +641,12 @@ int main(int argc, char** argv) {
 			break;
 
 		case 's':
-			result = parse_u32(optarg, &sample_rate_hz);
+			f_hz = strtod(optarg, &endptr);
+			if (optarg == endptr) {
+				result = HACKRF_ERROR_INVALID_PARAM;
+				break;
+			}
+			sample_rate_hz = f_hz;
 			sample_rate = true;
 			break;
 
@@ -652,7 +657,12 @@ int main(int argc, char** argv) {
 			break;
 
 		case 'b':
-			result = parse_u32(optarg, &baseband_filter_bw_hz);
+			f_hz = strtod(optarg, &endptr);
+			if (optarg == endptr) {
+				result = HACKRF_ERROR_INVALID_PARAM;
+				break;
+			}
+			baseband_filter_bw_hz = f_hz;
 			baseband_filter_bw = true;
 			break;
 

--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -748,7 +748,7 @@ int main(int argc, char** argv) {
 			freq_hz = if_freq_hz;
 			break;
 		case RF_PATH_FILTER_LOW_PASS:
-			freq_hz = labs((long int) if_freq_hz - lo_freq_hz);
+			freq_hz = (int64_t) labs(if_freq_hz - lo_freq_hz);
 			break;
 		case RF_PATH_FILTER_HIGH_PASS:
 			freq_hz = if_freq_hz + lo_freq_hz;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -30,6 +30,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #ifdef _WIN32
 /* Avoid redefinition of timespec from time.h (included by libusb.h) */
 #define HAVE_STRUCT_TIMESPEC 1
+
+/* Stop MSVC complaining about strdup()
+ * Sure, we could fix this another way if strdup() is ever deprecated
+ */
+#define _CRT_NONSTDC_NO_DEPRECATE 1
 #endif
 #include <pthread.h>
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -397,7 +397,7 @@ const char* ADDCALL hackrf_library_release()
 
 hackrf_device_list_t* ADDCALL hackrf_device_list()
 {
-	ssize_t i;
+	int i;
 	libusb_device_handle* usb_device = NULL;
 	uint8_t serial_descriptor_index;
 	char serial_number[64];
@@ -407,7 +407,7 @@ hackrf_device_list_t* ADDCALL hackrf_device_list()
 	if ( list == NULL )
 		return NULL;
 		
-	list->usb_devicecount = libusb_get_device_list(g_libusb_context, (libusb_device ***)&list->usb_devices);
+	list->usb_devicecount = (int) libusb_get_device_list(g_libusb_context, (libusb_device ***)&list->usb_devices);
 	
 	list->serial_numbers = calloc(list->usb_devicecount, sizeof(void *));
 	list->usb_board_ids = calloc(list->usb_devicecount, sizeof(enum hackrf_usb_board_id));
@@ -474,7 +474,7 @@ libusb_device_handle* hackrf_open_usb(const char* const desired_serial_number)
 	libusb_device_handle* usb_device = NULL;
 	libusb_device** devices = NULL;
 	const ssize_t list_length = libusb_get_device_list(g_libusb_context, &devices);
-	int match_len = 0;
+	ssize_t match_len = 0;
 	ssize_t i;
 	char serial_number[64];
 	int serial_number_length;
@@ -1225,7 +1225,8 @@ typedef struct {
  * described below.
  */
 int ADDCALL hackrf_set_sample_rate_manual(hackrf_device* device,
-                                       const uint32_t freq_hz, uint32_t divider)
+                                          const uint32_t freq_hz,
+                                          const uint32_t divider)
 {
 	set_fracrate_params_t set_fracrate_params;
 	uint8_t length;

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -30,11 +30,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #ifdef _WIN32
 /* Avoid redefinition of timespec from time.h (included by libusb.h) */
 #define HAVE_STRUCT_TIMESPEC 1
-
-/* Stop MSVC complaining about strdup()
- * Sure, we could fix this another way if strdup() is ever deprecated
- */
-#define _CRT_NONSTDC_NO_DEPRECATE
 #endif
 #include <pthread.h>
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -34,7 +34,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 /* Stop MSVC complaining about strdup()
  * Sure, we could fix this another way if strdup() is ever deprecated
  */
-#define _CRT_NONSTDC_NO_DEPRECATE 1
+#define _CRT_NONSTDC_NO_DEPRECATE
 #endif
 #include <pthread.h>
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -30,6 +30,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #ifdef _WIN32
 /* Avoid redefinition of timespec from time.h (included by libusb.h) */
 #define HAVE_STRUCT_TIMESPEC 1
+#define strdup _strdup
 #endif
 #include <pthread.h>
 


### PR DESCRIPTION
This fixes 27 build warnings from MSVC on Windows.  Most of these were warnings about loss of precision, so I've added some explicit casts which silences the warnings and makes it more obvious what the code is doing.  I think this is win-win.

In some places we were seeing the same warning repeated, so I have added a couple of helper functions to parse frequencies from command line arguments.