### PR TITLE
Don't require a C++ compiler

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -23,7 +23,7 @@
 cmake_minimum_required(VERSION 2.8.9)
 set(CMAKE_TOOLCHAIN_FILE toolchain-arm-cortex-m.cmake)
 
-project (hackrf_firmware_all)
+project (hackrf_firmware_all C)
 
 add_subdirectory(blinky)
 add_subdirectory(hackrf_usb)

--- a/firmware/blinky/CMakeLists.txt
+++ b/firmware/blinky/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 2.8.9)
 set(CMAKE_TOOLCHAIN_FILE ../toolchain-arm-cortex-m.cmake)
 
-project(blinky)
+project(blinky C)
 
 include(../hackrf-common.cmake)
 

--- a/firmware/hackrf_usb/CMakeLists.txt
+++ b/firmware/hackrf_usb/CMakeLists.txt
@@ -21,7 +21,7 @@
 cmake_minimum_required(VERSION 2.8.9)
 set(CMAKE_TOOLCHAIN_FILE ../toolchain-arm-cortex-m.cmake)
 
-project(hackrf_usb)
+project(hackrf_usb C)
 
 include(../hackrf-common.cmake)
 

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 #top dir cmake project for libhackrf + tools
 
 cmake_minimum_required(VERSION 2.8)
-project (HackRF)
+project (HackRF C)
 
 set(CMAKE_C_FLAGS "$ENV{CFLAGS}" CACHE STRING "C Flags")
 


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++.  By
explicitly passing 'C' as argument of the project() macro, we tell CMake
that only C is used, which prevents CMake from erroring out if a C++
compiler doesn't exist.