### PR TITLE
Travis OS X builds don't work with modern Xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       compiler: gcc
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       compiler: clang
 
 before_script:


### PR DESCRIPTION
Firmware builds are failing on OS X Travis builds because Xcode 8.3 doesn't include the pip tool. It is replaced by pip2 and pip3. Using pip2 installs the packages but it is later not found by the Python process used to build libopencm3.

See log here: https://travis-ci.org/dominicgs/hackrf/jobs/312689327#L1083

It would be great to use a more up to date Xcode, default is 8.3, but 9.2 is also now available.