### PR TITLE
Make compatible with kitspace.org (take 2)

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,3 @@
+site: https://greatscottgadgets.com/hackrf/
+gerbers: doc/hardware/hackrf-one-gerbers
+bom: doc/hardware/hackrf-one-bom.csv


### PR DESCRIPTION
Hey after #464, I added the ability to Kitspace to read csv (and xlsx, ods etc) so you would just need to add one file to have a HackRF page. You don't need to keep any additional files in sync. What do you think?

Here is a preview of the page: http://add-hackrf.preview.kitspace.org/boards/github.com/kitspace-forks/hackrf/