### PR TITLE
Fixed operation of switch --list

### DIFF
--- a/host/hackrf-tools/src/hackrf_operacake.c
+++ b/host/hackrf-tools/src/hackrf_operacake.c
@@ -50,7 +50,7 @@ static void usage() {
 static struct option long_options[] = {
 	{ "device", no_argument, 0, 'd' },
 	{ "address", no_argument, 0, 'o' },
-	{ "list", no_argument, 0, 'v' },
+	{ "list", no_argument, 0, 'l' },
 	{ "help", no_argument, 0, 'h' },
 	{ 0, 0, 0, 0 },
 };


### PR DESCRIPTION
The hackrf_operacake long option --list was producing an error message "unknown argument '-v (null)' ".