### PR TITLE
HackRF Opera Cake - GPIO test mode

### DIFF
--- a/firmware/common/operacake.h
+++ b/firmware/common/operacake.h
@@ -49,6 +49,7 @@ uint8_t operacake_init(void);
 uint8_t operacake_set_ports(uint8_t address, uint8_t PA, uint8_t PB);
 uint8_t operacake_add_range(uint16_t freq_min, uint16_t freq_max, uint8_t port);
 uint8_t operacake_set_range(uint32_t freq_mhz);
+uint16_t gpio_test(uint8_t address);
 
 #ifdef __cplusplus
 }

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -92,7 +92,8 @@ static const usb_request_handler_fn vendor_request_handler[] = {
 	usb_vendor_request_operacake_set_ranges,
 	usb_vendor_request_set_clkout_enable,
 	usb_vendor_request_spiflash_status,
-	usb_vendor_request_spiflash_clear_status
+	usb_vendor_request_spiflash_clear_status,
+	usb_vendor_request_operacake_gpio_test
 };
 
 static const uint32_t vendor_request_handler_count =

--- a/firmware/hackrf_usb/usb_api_operacake.c
+++ b/firmware/hackrf_usb/usb_api_operacake.c
@@ -74,3 +74,18 @@ usb_request_status_t usb_vendor_request_operacake_set_ranges(
 	}
 	return USB_REQUEST_STATUS_OK;
 }
+
+usb_request_status_t usb_vendor_request_operacake_gpio_test(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	uint16_t test_result;
+	uint8_t address = endpoint->setup.value & 0xFF;
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		test_result = gpio_test(address);
+		endpoint->buffer[0] = test_result & 0xff;
+		endpoint->buffer[1] = test_result >> 8;
+		usb_transfer_schedule_block(endpoint->in, &endpoint->buffer, 2, NULL, NULL);
+		usb_transfer_schedule_ack(endpoint->out);
+	}
+	return USB_REQUEST_STATUS_OK;
+}

--- a/firmware/hackrf_usb/usb_api_operacake.h
+++ b/firmware/hackrf_usb/usb_api_operacake.h
@@ -34,4 +34,7 @@ usb_request_status_t usb_vendor_request_operacake_set_ports(
 usb_request_status_t usb_vendor_request_operacake_set_ranges(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 
+usb_request_status_t usb_vendor_request_operacake_gpio_test(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+
 #endif /* end of include guard: __USB_API_OPERACAKE_H__ */

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -83,6 +83,7 @@ typedef enum {
 	HACKRF_VENDOR_REQUEST_CLKOUT_ENABLE = 32,
 	HACKRF_VENDOR_REQUEST_SPIFLASH_STATUS = 33,
 	HACKRF_VENDOR_REQUEST_SPIFLASH_CLEAR_STATUS = 34,
+	HACKRF_VENDOR_REQUEST_OPERACAKE_GPIO_TEST = 35,
 } hackrf_vendor_request;
 
 #define USB_CONFIG_STANDARD 0x1
@@ -2073,6 +2074,30 @@ int ADDCALL hackrf_set_clkout_enable(hackrf_device* device, const uint8_t value)
 
 	if (result != 0)
 	{
+		last_libusb_error = result;
+		return HACKRF_ERROR_LIBUSB;
+	} else {
+		return HACKRF_SUCCESS;
+	}
+}
+
+int ADDCALL hackrf_operacake_gpio_test(hackrf_device* device, const uint8_t address,
+                                       uint16_t* test_result)
+{
+	USB_API_REQUIRED(device, 0x0103)
+	int result;
+	result = libusb_control_transfer(
+		device->usb_device,
+		LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
+		HACKRF_VENDOR_REQUEST_OPERACAKE_GPIO_TEST,
+		address,
+		0,
+		(unsigned char*)test_result,
+		2,
+		0
+	);
+
+	if (result < 1) {
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
 	} else {

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -251,6 +251,10 @@ extern ADDAPI int ADDCALL hackrf_set_operacake_ranges(hackrf_device* device,
 
 extern ADDAPI int ADDCALL hackrf_set_clkout_enable(hackrf_device* device, const uint8_t value);
 
+extern ADDAPI int ADDCALL hackrf_operacake_gpio_test(hackrf_device* device,
+                                                     uint8_t address,
+													 uint16_t* test_result);
+
 #ifdef __cplusplus
 } // __cplusplus defined.
 #endif


### PR DESCRIPTION
Adds a GPIO test to `hackrf_operacake`.  You'll need to build and flash the firmware, then run `hackrf_operacake -o 24 -g`  (24 being the address of the EUT opera cake)