### PR TITLE
Switch to xenial build platform (no more containers)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: c
 
 cache: apt
 
-sudo: false
-dist: trusty
+dist: xenial
 
 os:
   - linux


### PR DESCRIPTION
It's more likely to represent the platform that users use.

Sadly Travis-ci announced that they're ditching the container based build environment, so no more container builds.  All VMs from now on, so I took out the `sudo: false` restriction.