### PR TITLE
Install g++ libs for arm embedded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - dfu-util
       - gcc-arm-none-eabi
       - libnewlib-arm-none-eabi
+      - libstdc++-arm-none-eabi-newlib
       - python-yaml
 
   homebrew:


### PR DESCRIPTION
While we don't have any C++ code, cmake tries to test g++ and it fails without the g++ libs to build against.