### PR TITLE
FIXED: remove garbage at the end when capturing to stdout ('-r -')

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -530,7 +530,7 @@ BOOL WINAPI
 sighandler(int signum)
 {
 	if (CTRL_C_EVENT == signum) {
-		fprintf(stdout, "Caught signal %d\n", signum);
+		fprintf(stderr, "Caught signal %d\n", signum);
 		do_exit = true;
 		return TRUE;
 	}
@@ -539,7 +539,7 @@ sighandler(int signum)
 #else
 void sigint_callback_handler(int signum) 
 {
-	fprintf(stdout, "Caught signal %d\n", signum);
+	fprintf(stderr, "Caught signal %d\n", signum);
 	do_exit = true;
 }
 #endif


### PR DESCRIPTION
When capturing on a Raspberry Pi 4, if you provide a filename (-r cap.iq), it stops at 2 GiB with a "Exiting... hackrf_is_streaming() result: streaming terminated (-1004)" message (32 bits problem?). If you use stdout (-r -) this limit disappears, but you get garbage at the end of the file coming from the signal handlers (that also print to stdout).

This is a simple fix to avoid that "problem" (not a big deal anyway).