### PR TITLE
fix _FILE_OFFSET_BITS 64 position in hackrf_transfer.c 

### DIFF
--- a/host/hackrf-tools/src/hackrf_transfer.c
+++ b/host/hackrf-tools/src/hackrf_transfer.c
@@ -20,6 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#define _FILE_OFFSET_BITS 64
 
 #include <hackrf.h>
 
@@ -33,8 +34,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-
-#define _FILE_OFFSET_BITS 64
 
 #ifndef bool
 typedef int bool;


### PR DESCRIPTION
hackrf_transfer failed to send file with size over 2G (in case 32bit system). Fix in hackrf_transfer.c  to change the position of the #define _FILE_OFFSET_BITS 64, must be defined before #include<sys/stat.h>
