### PR TITLE
Faster and cleaner exit from hackrf_sweep

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -742,14 +742,6 @@ int main(int argc, char** argv) {
 			sweep_count, time_diff, sweep_rate);
 
 	if(device != NULL) {
-		result = hackrf_stop_rx(device);
-		if(result != HACKRF_SUCCESS) {
-			fprintf(stderr, "hackrf_stop_rx() failed: %s (%d)\n",
-				   hackrf_error_name(result), result);
-		} else {
-			fprintf(stderr, "hackrf_stop_rx() done\n");
-		}
-
 		result = hackrf_close(device);
 		if(result != HACKRF_SUCCESS) {
 			fprintf(stderr, "hackrf_close() failed: %s (%d)\n",

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -727,6 +727,7 @@ int main(int argc, char** argv) {
 		}
 	}
 
+	fflush(outfile);
 	result = hackrf_is_streaming(device);	
 	if (do_exit) {
 		fprintf(stderr, "\nExiting...\n");

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -220,6 +220,9 @@ int rx_callback(hackrf_transfer* transfer) {
 		return -1;
 	}
 
+	if(do_exit) {
+		return 0;
+	}
 	gettimeofday(&usb_transfer_time, NULL);
 	byte_count += transfer->valid_length;
 	buf = (int8_t*) transfer->buffer;


### PR DESCRIPTION
Thoroughly tested on Linux and macOS.

### The three commits

**hackrf_sweep: flush output earlier**
Gives listener access to complete data faster.
Otherwise the data might be delayed until the whole closing procedure is done.

**hackrf_sweep: speed up ending by removing unnecessary code**
hackrf_stop_rx() is handled in hackrf_close(), so there seems to be no need
to call it separately.  Furthermore, if hackrf_stop() is called separately,
it causes hackrf_close() to take more than half a second longer.

**hackrf_sweep: exit early from rx_callback if do_exit set**
Sometimes, if a small frequency interval is scanned, the callback is
triggered even though we already have the number of sweeps we want, and
sweep_count gets increased, showing the wrong "Total sweeps".

### Some logs to show the effects

#### Before - showing how last part is delayed because it is flushed after hackrf_close
`time hackrf-tools/src/hackrf_sweep -f 100:320 -1 2>&1 |ts -i "%.s" |ts -s "%.s"`
```
0.005210 0.000013 call hackrf_sample_rate_set(20.000 MHz)
0.005322 0.000090 call hackrf_baseband_filter_bandwidth_set(15.000 MHz)
0.005356 0.000016 Sweeping from 100 MHz to 320 MHz
0.005380 0.000012 Stop with Ctrl-C
0.044890 0.039483 2021-03-20, 11:17:48.816645, 100000000, 105000000, 1000000.00, 20, -57.02, -69.59, -60.38, -63.00, -64.25
0.045092 0.000139 2021-03-20, 11:17:48.816645, 110000000, 115000000, 1000000.00, 20, -67.92, -65.04, -65.30, -72.25, -64.74
0.045195 0.000061 2021-03-20, 11:17:48.816645, 105000000, 110000000, 1000000.00, 20, -55.18, -51.33, -56.16, -65.99, -77.60
0.045267 0.000046 2021-03-20, 11:17:48.816645, 115000000, 120000000, 1000000.00, 20, -64.34, -60.89, -61.56, -68.49, -62.72
0.045322 0.000047 2021-03-20, 11:17:48.816645, 120000000, 125000000, 1000000.00, 20, -69.09, -89.13, -67.00, -63.76, -81.10
0.045358 0.000129 2021-03-20, 11:17:48.816645, 130000000, 135000000, 1000000.00, 20, -67.61, -63.68, -72.27, -67.46, -65.74
0.045397 0.000104 2021-03-20, 11:17:48.816645, 125000000, 130000000, 1000000.00, 20, -62.74, -63.19, -62.10, -56.15, -57.95
0.045433 0.000045 2021-03-20, 11:17:48.816645, 135000000, 140000000, 1000000.00, 20, -62.28, -65.50, -76.30, -63.15, -58.56
0.045474 0.000037 2021-03-20, 11:17:48.816645, 140000000, 145000000, 1000000.00, 20, -62.56, -68.63, -62.94, -63.51, -61.05
0.045511 0.000037 2021-03-20, 11:17:48.816645, 150000000, 155000000, 1000000.00, 20, -69.86, -61.14, -60.41, -59.61, -60.48
0.045564 0.000037 2021-03-20, 11:17:48.816645, 145000000, 150000000, 1000000.00, 20, -63.04, -65.42, -61.97, -60.62, -69.46
0.045628 0.000036 2021-03-20, 11:17:48.816645, 155000000, 160000000, 1000000.00, 20, -59.43, -58.20, -59.03, -67.10, -61.86
0.045688 0.000037 2021-03-20, 11:17:48.816645, 160000000, 165000000, 1000000.00, 20, -58.64, -62.26, -60.58, -61.14, -60.26
0.045738 0.000033 2021-03-20, 11:17:48.816645, 170000000, 175000000, 1000000.00, 20, -76.84, -67.61, -71.70, -83.12, -65.31
0.045784 0.000038 2021-03-20, 11:17:48.816645, 165000000, 170000000, 1000000.00, 20, -64.96, -61.82, -60.42, -60.64, -61.63
0.045836 0.000040 2021-03-20, 11:17:48.816645, 175000000, 180000000, 1000000.00, 20, -68.26, -71.37, -63.06, -66.31, -65.44
0.045886 0.000034 2021-03-20, 11:17:48.816645, 180000000, 185000000, 1000000.00, 20, -64.80, -62.04, -61.65, -61.36, -65.39
0.045936 0.000033 2021-03-20, 11:17:48.816645, 190000000, 195000000, 1000000.00, 20, -71.47, -64.87, -62.46, -63.45, -62.05
0.045981 0.000034 2021-03-20, 11:17:48.816645, 185000000, 190000000, 1000000.00, 20, -67.42, -67.26, -60.40, -62.63, -69.24
0.046023 0.000039 2021-03-20, 11:17:48.816645, 195000000, 200000000, 1000000.00, 20, -63.82, -67.46, -68.07, -79.95, -59.77
0.046076 0.000058 2021-03-20, 11:17:48.816645, 200000000, 205000000, 1000000.00, 20, -56.25, -64.99, -67.27, -66.46, -78.62
0.046131 0.000040 2021-03-20, 11:17:48.816645, 210000000, 215000000, 1000000.00, 20, -62.25, -63.44, -70.98, -64.24, -60.42
0.046171 0.000038 2021-03-20, 11:17:48.816645, 205000000, 210000000, 1000000.00, 20, -61.24, -58.58, -65.71, -65.62, -60.07
0.046207 0.000034 2021-03-20, 11:17:48.816645, 215000000, 220000000, 1000000.00, 20, -61.18, -60.89, -63.95, -77.16, -73.12
0.046260 0.000051 2021-03-20, 11:17:48.816645, 220000000, 225000000, 1000000.00, 20, -60.23, -62.44, -70.85, -66.03, -64.57
0.046323 0.000039 2021-03-20, 11:17:48.816645, 230000000, 235000000, 1000000.00, 20, -56.54, -59.94, -63.92, -61.16, -60.57
0.046367 0.000039 2021-03-20, 11:17:48.816645, 225000000, 230000000, 1000000.00, 20, -60.14, -61.40, -72.02, -67.88, -65.21
0.046410 0.000038 2021-03-20, 11:17:48.816645, 235000000, 240000000, 1000000.00, 20, -59.13, -64.43, -62.23, -60.46, -56.04
0.046461 0.000034 2021-03-20, 11:17:48.816645, 240000000, 245000000, 1000000.00, 20, -52.52, -59.84, -54.87, -53.68, -57.97
0.046516 0.000093 2021-03-20, 11:17:48.816645, 250000000, 255000000, 1000000.00, 20, -61.45, -59.44, -60.98, -62.84, -64.27
0.046556 0.000046 2021-03-20, 11:17:48.816645, 245000000, 250000000, 1000000.00, 20, -59.59, -58.91, -62.35, -68.35, -65.35
0.046596 0.000062 2021-03-20, 11:17:48.816645, 255000000, 260000000, 1000000.00, 20, -62.95, -68.17, -68.70, -68.88, -65.56
0.046651 0.000051 2021-03-20, 11:17:48.816645, 260000000, 265000000, 1000000.00, 20, -58.52, -61.71, -69.89, -70.67, -60.23
0.046706 0.000072 2021-03-20, 11:17:48.816645, 270000000, 275000000, 1000000.00, 20, -58.17, -62.15, -74.82, -73.63, -61.40
0.046746 0.000042 2021-03-20, 11:17:48.816645, 265000000, 270000000, 1000000.00, 20, -64.10, -64.01, -62.27, -61.94, -62.44
0.046783 0.000035 2021-03-20, 11:17:48.816645, 275000000, 280000000, 1000000.00, 20, -68.60, -69.17, -74.43, -74.38, -63.28
0.046819 0.000051 2021-03-20, 11:17:48.816645, 280000000, 285000000, 1000000.00, 20, -63.25, -66.71, -61.74, -60.55, -63.44
0.046869 0.000037 2021-03-20, 11:17:48.816645, 290000000, 295000000, 1000000.00, 20, -56.87, -61.10, -64.44, -59.98, -57.86
0.054788 0.008116 2021-03-20, 11:17:48.816645, 285000000, 290000000, 1000000.00, 20, -
0.054906 0.000090 Exiting...
0.054973 0.000070 Total sweeps: 1 in 0.05011 seconds (0.00 sweeps/second)
0.065948 0.010977 hackrf_stop_rx() done
0.577893 0.511784 hackrf_close() done
0.578277 0.000462 hackrf_exit() done
0.578523 0.000346 63.99, -60.10, -57.53, -57.25, -60.91
0.578722 0.000215 2021-03-20, 11:17:48.816645, 295000000, 300000000, 1000000.00, 20, -67.08, -61.35, -59.21, -58.48, -62.53
0.578868 0.000070 2021-03-20, 11:17:48.816645, 300000000, 305000000, 1000000.00, 20, -64.43, -72.51, -66.21, -58.95, -59.60
0.579156 0.000227 2021-03-20, 11:17:48.816645, 310000000, 315000000, 1000000.00, 20, -59.81, -60.91, -68.36, -64.86, -58.53
0.579269 0.000122 2021-03-20, 11:17:48.816645, 305000000, 310000000, 1000000.00, 20, -63.64, -63.02, -61.68, -54.00, -54.09
0.579389 0.000052 2021-03-20, 11:17:48.816645, 315000000, 320000000, 1000000.00, 20, -60.40, -62.17, -61.39, -61.12, -54.05
0.579488 0.000056 exit

real    0m0.619s
user    0m0.092s
sys     0m0.016s
```

#### After - showing the closing speedup and the effects of the early flush
`time hackrf-tools/src/hackrf_sweep -f 100:320 -1 2>&1 |ts -i "%.s" |ts -s "%.s"`
```

0.000009 0.000014 call hackrf_sample_rate_set(20.000 MHz)
0.000073 0.000078 call hackrf_baseband_filter_bandwidth_set(15.000 MHz)
0.000113 0.000017 Sweeping from 100 MHz to 320 MHz
0.000137 0.000013 Stop with Ctrl-C
0.022135 0.022825 2021-03-20, 11:32:51.866080, 100000000, 105000000, 1000000.00, 20, -57.10, -65.99, -65.71, -61.86, -63.24
0.022249 0.000130 2021-03-20, 11:32:51.866080, 110000000, 115000000, 1000000.00, 20, -61.16, -65.00, -66.76, -67.53, -60.37
0.022294 0.000058 2021-03-20, 11:32:51.866080, 105000000, 110000000, 1000000.00, 20, -66.61, -56.45, -59.36, -65.33, -57.68
0.022332 0.000046 2021-03-20, 11:32:51.866080, 115000000, 120000000, 1000000.00, 20, -59.82, -65.15, -75.01, -63.20, -57.15
0.022368 0.000045 2021-03-20, 11:32:51.866080, 120000000, 125000000, 1000000.00, 20, -57.61, -61.76, -72.20, -67.69, -63.20
0.022402 0.000021 2021-03-20, 11:32:51.866080, 130000000, 135000000, 1000000.00, 20, -74.77, -72.43, -66.34, -69.07, -70.65
0.022441 0.000023 2021-03-20, 11:32:51.866080, 125000000, 130000000, 1000000.00, 20, -63.55, -75.02, -68.52, -62.35, -66.26
0.022477 0.000026 2021-03-20, 11:32:51.866080, 135000000, 140000000, 1000000.00, 20, -63.56, -65.40, -67.33, -70.18, -64.58
0.022512 0.000018 2021-03-20, 11:32:51.866080, 140000000, 145000000, 1000000.00, 20, -60.56, -67.03, -74.52, -72.22, -71.20
0.022548 0.000023 2021-03-20, 11:32:51.866080, 150000000, 155000000, 1000000.00, 20, -63.14, -63.80, -65.76, -67.49, -56.06
0.022586 0.000020 2021-03-20, 11:32:51.866080, 145000000, 150000000, 1000000.00, 20, -57.52, -62.56, -64.45, -60.60, -59.63
0.022628 0.000020 2021-03-20, 11:32:51.866080, 155000000, 160000000, 1000000.00, 20, -55.65, -62.29, -67.80, -70.54, -66.01
0.022663 0.000024 2021-03-20, 11:32:51.866080, 160000000, 165000000, 1000000.00, 20, -62.57, -61.91, -57.78, -63.66, -61.62
0.022713 0.000017 2021-03-20, 11:32:51.866080, 170000000, 175000000, 1000000.00, 20, -63.19, -67.06, -63.80, -64.07, -77.81
0.022755 0.000023 2021-03-20, 11:32:51.866080, 165000000, 170000000, 1000000.00, 20, -60.26, -66.82, -65.82, -65.53, -65.08
0.022794 0.000017 2021-03-20, 11:32:51.866080, 175000000, 180000000, 1000000.00, 20, -73.57, -63.34, -60.01, -58.97, -63.14
0.022839 0.000023 2021-03-20, 11:32:51.866080, 180000000, 185000000, 1000000.00, 20, -58.55, -64.49, -73.19, -71.88, -70.67
0.022875 0.000021 2021-03-20, 11:32:51.866080, 190000000, 195000000, 1000000.00, 20, -67.30, -66.92, -77.31, -62.56, -59.72
0.022960 0.000035 2021-03-20, 11:32:51.866080, 185000000, 190000000, 1000000.00, 20, -59.62, -61.93, -64.71, -63.70, -63.34
0.023018 0.000033 2021-03-20, 11:32:51.866080, 195000000, 200000000, 1000000.00, 20, -66.80, -77.67, -63.46, -81.70, -58.39
0.023058 0.000029 2021-03-20, 11:32:51.866080, 200000000, 205000000, 1000000.00, 20, -61.37, -62.24, -66.34, -64.15, -63.78
0.023103 0.000027 2021-03-20, 11:32:51.866080, 210000000, 215000000, 1000000.00, 20, -59.04, -68.84, -64.32, -62.19, -68.10
0.023208 0.000029 2021-03-20, 11:32:51.866080, 205000000, 210000000, 1000000.00, 20, -62.87, -63.39, -62.73, -65.91, -67.36
0.023318 0.000027 2021-03-20, 11:32:51.866080, 215000000, 220000000, 1000000.00, 20, -61.27, -69.42, -67.06, -58.76, -57.88
0.023366 0.000027 2021-03-20, 11:32:51.866080, 220000000, 225000000, 1000000.00, 20, -56.66, -56.62, -75.06, -61.65, -58.93
0.023472 0.000028 2021-03-20, 11:32:51.866080, 230000000, 235000000, 1000000.00, 20, -60.38, -60.67, -70.03, -63.08, -64.63
0.023514 0.000032 2021-03-20, 11:32:51.866080, 225000000, 230000000, 1000000.00, 20, -57.45, -66.65, -71.02, -72.81, -62.57
0.023586 0.000031 2021-03-20, 11:32:51.866080, 235000000, 240000000, 1000000.00, 20, -56.61, -60.12, -73.62, -64.15, -53.37
0.023641 0.000019 2021-03-20, 11:32:51.866080, 240000000, 245000000, 1000000.00, 20, -67.83, -56.47, -56.15, -59.04, -79.34
0.023712 0.000056 2021-03-20, 11:32:51.866080, 250000000, 255000000, 1000000.00, 20, -61.44, -59.55, -60.11, -65.56, -70.59
0.023766 0.000037 2021-03-20, 11:32:51.866080, 245000000, 250000000, 1000000.00, 20, -51.50, -50.75, -47.81, -47.93, -48.49
0.023812 0.000033 2021-03-20, 11:32:51.866080, 255000000, 260000000, 1000000.00, 20, -48.62, -47.74, -48.60, -49.64, -50.32
0.023858 0.000029 2021-03-20, 11:32:51.866080, 260000000, 265000000, 1000000.00, 20, -54.40, -61.65, -57.30, -50.85, -51.70
0.023923 0.000020 2021-03-20, 11:32:51.866080, 270000000, 275000000, 1000000.00, 20, -56.54, -54.18, -52.32, -52.10, -52.00
0.023967 0.000027 2021-03-20, 11:32:51.866080, 265000000, 270000000, 1000000.00, 20, -58.53, -61.45, -62.02, -55.13, -58.84
0.024032 0.000033 2021-03-20, 11:32:51.866080, 275000000, 280000000, 1000000.00, 20, -63.37, -59.51, -56.02, -59.02, -59.68
0.024075 0.000034 2021-03-20, 11:32:51.866080, 280000000, 285000000, 1000000.00, 20, -66.31, -68.54, -70.75, -66.87, -63.06
0.024129 0.000027 2021-03-20, 11:32:51.866080, 290000000, 295000000, 1000000.00, 20, -62.94, -69.69, -65.44, -61.43, -77.04
0.032039 0.008780 2021-03-20, 11:32:51.866080, 285000000, 290000000, 1000000.00, 20, -63.64, -59.09, -54.48, -55.35, -61.98
0.032164 0.000094 2021-03-20, 11:32:51.866080, 295000000, 300000000, 1000000.00, 20, -66.62, -61.17, -62.86, -68.29, -66.69
0.032245 0.000045 2021-03-20, 11:32:51.866080, 300000000, 305000000, 1000000.00, 20, -57.01, -59.53, -65.54, -80.67, -69.16
0.032302 0.000033 2021-03-20, 11:32:51.866080, 310000000, 315000000, 1000000.00, 20, -60.63, -61.76, -76.18, -62.69, -65.63
0.032351 0.000029 2021-03-20, 11:32:51.866080, 305000000, 310000000, 1000000.00, 20, -61.93, -63.40, -65.18, -74.02, -71.64
0.032395 0.000031 2021-03-20, 11:32:51.866080, 315000000, 320000000, 1000000.00, 20, -53.33, -54.93, -70.32, -69.53, -58.48
0.032443 0.000034 
0.032495 0.000034 Exiting...
0.032553 0.000042 Total sweeps: 1 in 0.05009 seconds (0.00 sweeps/second)
0.053818 0.021370 hackrf_close() done
0.053922 0.000179 hackrf_exit() done
0.053977 0.000095 exit

real    0m0.098s
user    0m0.100s
sys     0m0.011s
```

#### Before - with more logging - showing duplicate calls at end, and also wrong "Total sweeps"
`time hackrf-tools/src/hackrf_sweep -f 100:120 -1 2>&1 |ts -i "%.s" |ts -s "%.s"`
```
0.000012 0.000015 hackrf_init start
0.000077 0.000073 hackrf_init return success
0.000107 0.000015 allocate_transfers start
0.000129 0.000012 allocate_transfers return success
0.000151 0.000011 call hackrf_sample_rate_set(20.000 MHz)
0.000170 0.000010 call hackrf_baseband_filter_bandwidth_set(15.000 MHz)
0.000192 0.000011 Sweeping from 100 MHz to 120 MHz
0.000216 0.000011 hackrf_init_sweep start
0.000237 0.000010 hackrf_init_sweep return success
0.000258 0.000010 hackrf_start_rx_sweep start
0.000281 0.000010 prepare_transfers start
0.000302 0.000010 prepare_transfers return success
0.000324 0.000010 hackrf_start_rx_sweep return
0.000346 0.000010 Stop with Ctrl-C
0.031666 0.034590 
0.031879 0.000171 Exiting...
0.032040 0.000101 Total sweeps: 2 in 0.05014 seconds (0.00 sweeps/second)
0.032142 0.000169 hackrf_stop_rx start
0.032192 0.000083 cancel_transfers start
0.032225 0.000100 cancel_transfers return success
0.032271 0.000064 hackrf_stop_rx return via stop_rx_command
0.032308 0.000031 hackrf_stop_rx_cmd start
0.042691 0.010420 hackrf_stop_rx_cmd end
0.042776 0.000067 hackrf_stop_rx() done
0.042829 0.000042 hackrf_close start
0.042876 0.000037 hackrf_stop_rx_cmd start
0.053265 0.010389 hackrf_stop_rx_cmd end
0.063734 0.010393 hackrf_close - call kill_transfer_thread
0.063960 0.000127 kill_transfer_thread start
0.064097 0.000112 cancel_transfers start
0.064227 0.000096 cancel_transfers return error-other
0.554369 0.490188 kill_transfer_thread end success
0.554638 0.000296 free_transfers start
0.555777 0.000759 free_transfers return
0.555905 0.000159 hackrf_close return result1
0.555977 0.000053 hackrf_close() done
0.556037 0.000046 hackrf_exit start
0.556208 0.000044 hackrf_exit return success
0.556303 0.000044 hackrf_exit() done
0.556459 0.000044 2021-03-20, 11:36:33.570027, 100000000, 105000000, 1000000.00, 20, -64.09, -62.03, -61.03, -64.30, -73.08
0.556564 0.000046 2021-03-20, 11:36:33.570027, 110000000, 115000000, 1000000.00, 20, -61.59, -66.77, -60.10, -57.81, -63.57
0.556662 0.000047 2021-03-20, 11:36:33.570027, 105000000, 110000000, 1000000.00, 20, -74.89, -54.29, -57.19, -70.16, -65.37
0.556758 0.000045 2021-03-20, 11:36:33.570027, 115000000, 120000000, 1000000.00, 20, -60.85, -63.20, -61.38, -61.70, -85.93
0.556853 0.000043 exit

real    0m0.601s
user    0m0.104s
sys     0m0.009s
```

#### After - with more logging - showing cleaner end, and correct "Total sweeps"
`time hackrf-tools/src/hackrf_sweep -f 100:120 -1 2>&1 |ts -i "%.s" |ts -s "%.s"`
```
time hackrf-tools/src/hackrf_sweep -f 100:120 -1 2>&1 |ts -i "%.s" |ts -s "%.s" 
0.004096 0.000011 hackrf_init start
0.004188 0.000068 hackrf_init return success
0.004219 0.000024 allocate_transfers start
0.004241 0.000012 allocate_transfers return success
0.004260 0.000011 call hackrf_sample_rate_set(20.000 MHz)
0.004282 0.000011 call hackrf_baseband_filter_bandwidth_set(15.000 MHz)
0.004304 0.000010 Sweeping from 100 MHz to 120 MHz
0.004326 0.000011 hackrf_init_sweep start
0.004348 0.000010 hackrf_init_sweep return success
0.004370 0.000010 hackrf_start_rx_sweep start
0.004391 0.000011 prepare_transfers start
0.004414 0.000014 prepare_transfers return success
0.004436 0.000018 hackrf_start_rx_sweep return
0.004460 0.000019 Stop with Ctrl-C
0.036066 0.031588 2021-03-20, 11:42:02.983704, 100000000, 105000000, 1000000.00, 20, -56.94, -65.63, -62.17, -61.21, -61.95
0.036321 0.000206 2021-03-20, 11:42:02.983704, 110000000, 115000000, 1000000.00, 20, -63.16, -61.98, -61.24, -60.85, -60.66
0.036466 0.000098 2021-03-20, 11:42:02.983704, 105000000, 110000000, 1000000.00, 20, -54.98, -56.07, -64.42, -65.39, -67.49
0.036600 0.000065 2021-03-20, 11:42:02.983704, 115000000, 120000000, 1000000.00, 20, -65.93, -62.15, -58.79, -58.04, -63.09
0.036740 0.000089 
0.036862 0.000112 Exiting...
0.037037 0.000128 Total sweeps: 1 in 0.05014 seconds (0.00 sweeps/second)
0.037150 0.000112 hackrf_close start
0.037204 0.000104 hackrf_stop_rx_cmd start
0.046493 0.009511 hackrf_stop_rx_cmd end
0.057032 0.010421 hackrf_close - call kill_transfer_thread
0.057366 0.000363 kill_transfer_thread start
0.057552 0.000181 cancel_transfers start
0.057700 0.000168 cancel_transfers return success
0.058613 0.000729 kill_transfer_thread end success
0.058705 0.000126 free_transfers start
0.058761 0.000052 free_transfers return
0.058813 0.000052 hackrf_close return result1
0.058867 0.000046 hackrf_close() done
0.058917 0.000047 hackrf_exit start
0.058966 0.000049 hackrf_exit return success
0.059017 0.000047 hackrf_exit() done
0.059098 0.000038 exit

real    0m0.099s
user    0m0.074s
sys     0m0.034s
```

### Logs showing speedup
Running 30 sweeps with
`time ( for (( i=1; i<=30; i++ )); do time hackrf-tools/src/hackrf_sweep -f 100:120 -1; echo "run $i finished"; done ) 2>&1 |ts -s "%.s" |egrep run`

#### Before
```
0.558287 run 1 finished
1.150118 run 2 finished
1.741484 run 3 finished
2.334307 run 4 finished
2.925169 run 5 finished
3.516332 run 6 finished
4.107328 run 7 finished
4.696787 run 8 finished
5.286594 run 9 finished
5.878449 run 10 finished
6.471626 run 11 finished
7.063373 run 12 finished
7.653655 run 13 finished
8.243900 run 14 finished
8.835613 run 15 finished
9.430429 run 16 finished
10.020425 run 17 finished
10.611297 run 18 finished
11.203124 run 19 finished
11.794890 run 20 finished
12.386230 run 21 finished
12.977029 run 22 finished
13.568459 run 23 finished
14.160142 run 24 finished
14.752768 run 25 finished
15.345201 run 26 finished
15.935046 run 27 finished
16.526353 run 28 finished
17.117542 run 29 finished
17.708193 run 30 finished

real    0m17.746s
user    0m0.453s
sys     0m0.338s
```
#### After
```
0.055590 run 1 finished            
0.145423 run 2 finished              
0.237678 run 3 finished                                   
0.328451 run 4 finished
0.419237 run 5 finished
0.508798 run 6 finished
0.597948 run 7 finished
0.688656 run 8 finished
0.778711 run 9 finished
0.870771 run 10 finished
0.961753 run 11 finished
1.053927 run 12 finished
1.146143 run 13 finished
1.238702 run 14 finished
1.328987 run 15 finished
1.420118 run 16 finished
1.511494 run 17 finished
1.601568 run 18 finished
1.691909 run 19 finished
1.781972 run 20 finished
1.872592 run 21 finished
1.963381 run 22 finished
2.054712 run 23 finished
2.146892 run 24 finished
2.236106 run 25 finished
2.322603 run 26 finished
2.409497 run 27 finished
2.500416 run 28 finished
2.592894 run 29 finished
2.684828 run 30 finished

real    0m2.728s
user    0m0.448s
sys     0m0.311s
```

(When running many times in a row on macOS, failures appear, both with and without these changes - equally often.)