### PR TITLE
Adding call to _setmode for Windows only to specify binary stdout output piping.

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -584,6 +584,12 @@ int main(int argc, char** argv) {
 		window[i] = (float) (0.5f * (1.0f - cos(2 * M_PI * i / (fftSize - 1))));
 	}
 
+#ifdef _MSC_VER
+	if(binary_output) {
+		_setmode(_fileno(stdout), _O_BINARY);
+	}
+#endif
+
 	result = hackrf_init();
 	if( result != HACKRF_SUCCESS ) {
 		fprintf(stderr, "hackrf_init() failed: %s (%d)\n", hackrf_error_name(result), result);


### PR DESCRIPTION
If the binary mode flag -B is set, also set the process's stdout pipe mode to binary mode. If this is not done, the underlying c standard library functions on windows will assume text-mode and try to convert any 0x0A bytes to 0x0A 0x0D, mangling the binary output. This fixes QSpectrumAnalyzer being able to parse the binary output of the latest version hackrf_sweep on Windows.

See Issue #871 