### PR TITLE
hackrf_sweep: Calculate and show sweep rate for subsecond sweeps

### DIFF
--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -398,7 +398,7 @@ int main(int argc, char** argv) {
 	struct timeval time_now;
 	struct timeval time_prev;
 	float time_diff;
-	float sweep_rate;
+	float sweep_rate = 0;
 	unsigned int lna_gain=16, vga_gain=20;
 	uint32_t freq_min = 0;
 	uint32_t freq_max = 6000;

--- a/host/hackrf-tools/src/hackrf_sweep.c
+++ b/host/hackrf-tools/src/hackrf_sweep.c
@@ -741,6 +741,8 @@ int main(int argc, char** argv) {
 
 	gettimeofday(&time_now, NULL);
 	time_diff = TimevalDiff(&time_now, &t_start);
+	if((sweep_rate == 0) && (time_diff > 0))
+		sweep_rate = sweep_count / time_diff;
 	fprintf(stderr, "Total sweeps: %" PRIu64 " in %.5f seconds (%.2f sweeps/second)\n",
 			sweep_count, time_diff, sweep_rate);
 


### PR DESCRIPTION
With this change,
`hackrf_sweep -f 100:120 -N 100`
reports
```
Total sweeps: 100 in 0.30062 seconds (332.64 sweeps/second)
```
instead of
```
Total sweeps: 100 in 0.30061 seconds (0.00 sweeps/second)
```