### PR TITLE
cmake/modules/FindFFTW.cmake: fix build without fftw3

### DIFF
--- a/host/cmake/modules/FindFFTW.cmake
+++ b/host/cmake/modules/FindFFTW.cmake
@@ -16,7 +16,7 @@ IF (WIN32)
 include_directories(${FFTW_INCLUDES})
 find_library (FFTW_LIBRARIES NAMES ${FFTW_LIBRARIES})
 ELSE(WIN32)
-find_library (FFTW_LIBRARIES NAMES fftw3)
+find_library (FFTW_LIBRARIES NAMES fftw3f)
 ENDIF(WIN32)
 
 


### PR DESCRIPTION
Build on Linux fails if libfftw3 is not available since commit https://github.com/greatscottgadgets/hackrf/commit/a8c1fc92e9fa10843cb4aafd68c52f9903ebd05d which replaced `pkg_check_modules(FFTW REQUIRED fftw3f)` by `find_package(FFTW REQUIRED)`

Fix this build failure by updating `FindFFTW.cmake` to check for `fftw3f`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>