### PR TITLE
FEAT: scheduled frequency change

### DIFF
--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -126,6 +126,7 @@ static usb_request_handler_fn vendor_request_handler[] = {
 	usb_vendor_request_read_supported_platform,
 	usb_vendor_request_set_leds,
 	usb_vendor_request_user_config_set_bias_t_opts,
+	usb_vendor_request_set_freq_when,
 };
 
 static const uint32_t vendor_request_handler_count =

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -454,8 +454,10 @@ void rx_mode(uint32_t seq)
 		uint32_t local_m0_count = m0_state.m0_count;
 
 		/* Check if scheduled frequency change is due, handles integer wrap-around */
-		if (frequency_switch_scheduled && !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
-			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL + set_freq_when_params.freq_hz;
+		if (frequency_switch_scheduled &&
+		    !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
+			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL +
+				set_freq_when_params.freq_hz;
 			set_freq(freq);
 			frequency_switch_scheduled = 0;
 		}
@@ -500,8 +502,10 @@ void tx_mode(uint32_t seq)
 		}
 
 		/* Check if scheduled frequency change is due, handles integer wrap-around */
-		if (frequency_switch_scheduled && !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
-			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL + set_freq_when_params.freq_hz;
+		if (frequency_switch_scheduled &&
+		    !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
+			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL +
+				set_freq_when_params.freq_hz;
 			set_freq(freq);
 			frequency_switch_scheduled = 0;
 		}

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -49,12 +49,22 @@
 
 #define USB_TRANSFER_SIZE 0x4000
 
+static int frequency_switch_scheduled = 0;
+
 typedef struct {
 	uint32_t freq_mhz;
 	uint32_t freq_hz;
 } set_freq_params_t;
 
 set_freq_params_t set_freq_params;
+
+typedef struct {
+	uint32_t freq_mhz;
+	uint32_t freq_hz;
+	uint32_t when;
+} set_freq_when_params_t;
+
+set_freq_when_params_t set_freq_when_params;
 
 struct set_freq_explicit_params {
 	uint64_t if_freq_hz; /* intermediate frequency */
@@ -108,6 +118,29 @@ usb_request_status_t usb_vendor_request_set_freq(
 			return USB_REQUEST_STATUS_OK;
 		}
 		return USB_REQUEST_STATUS_STALL;
+	} else {
+		return USB_REQUEST_STATUS_OK;
+	}
+}
+
+usb_request_status_t usb_vendor_request_set_freq_when(
+	usb_endpoint_t* const endpoint,
+	const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		usb_transfer_schedule_block(
+			endpoint->out,
+			&set_freq_when_params,
+			sizeof(set_freq_when_params_t),
+			NULL,
+			NULL);
+		return USB_REQUEST_STATUS_OK;
+	} else if (stage == USB_TRANSFER_STAGE_DATA) {
+		if (frequency_switch_scheduled)
+			return USB_REQUEST_STATUS_STALL;
+		frequency_switch_scheduled = 1;
+		usb_transfer_schedule_ack(endpoint->in);
+		return USB_REQUEST_STATUS_OK;
 	} else {
 		return USB_REQUEST_STATUS_OK;
 	}
@@ -415,9 +448,18 @@ void rx_mode(uint32_t seq)
 	transceiver_startup(TRANSCEIVER_MODE_RX);
 
 	baseband_streaming_enable(&sgpio_config);
+	frequency_switch_scheduled = 0;
 
 	while (transceiver_request.seq == seq) {
-		if ((m0_state.m0_count - usb_count) >= USB_TRANSFER_SIZE) {
+		uint32_t local_m0_count = m0_state.m0_count;
+
+		/* Check if scheduled frequency change is due, handles integer wrap-around */
+		if (frequency_switch_scheduled && !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
+			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL + set_freq_when_params.freq_hz;
+			set_freq(freq);
+			frequency_switch_scheduled = 0;
+		}
+		if ((local_m0_count - usb_count) >= USB_TRANSFER_SIZE) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_in,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],
@@ -447,13 +489,23 @@ void tx_mode(uint32_t seq)
 		NULL);
 	usb_count += USB_TRANSFER_SIZE;
 
+	frequency_switch_scheduled = 0;
+
 	while (transceiver_request.seq == seq) {
+		uint32_t local_m0_count = m0_state.m0_count;
 		if (!started && (m0_state.m4_count == USB_BULK_BUFFER_SIZE)) {
 			// Buffer is now full, start streaming.
 			baseband_streaming_enable(&sgpio_config);
 			started = true;
 		}
-		if ((usb_count - m0_state.m0_count) <= USB_TRANSFER_SIZE) {
+
+		/* Check if scheduled frequency change is due, handles integer wrap-around */
+		if (frequency_switch_scheduled && !((local_m0_count - set_freq_when_params.when) & 0x80000000)) {
+			const uint64_t freq = set_freq_when_params.freq_mhz * 1000000ULL + set_freq_when_params.freq_hz;
+			set_freq(freq);
+			frequency_switch_scheduled = 0;
+		}
+		if ((usb_count - local_m0_count) <= USB_TRANSFER_SIZE) {
 			usb_transfer_schedule_block(
 				&usb_endpoint_bulk_out,
 				&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK],

--- a/firmware/hackrf_usb/usb_api_transceiver.h
+++ b/firmware/hackrf_usb/usb_api_transceiver.h
@@ -45,6 +45,9 @@ usb_request_status_t usb_vendor_request_set_baseband_filter_bandwidth(
 usb_request_status_t usb_vendor_request_set_freq(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
+usb_request_status_t usb_vendor_request_set_freq_when(
+	usb_endpoint_t* const endpoint,
+	const usb_transfer_stage_t stage);
 usb_request_status_t usb_vendor_request_set_sample_rate_frac(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1451,7 +1451,10 @@ typedef struct {
 	uint32_t when;
 } set_freq_when_params_t;
 
-int ADDCALL hackrf_set_freq_when(hackrf_device* device, const uint64_t freq_hz, const uint32_t when)
+int ADDCALL hackrf_set_freq_when(
+	hackrf_device* device,
+	const uint64_t freq_hz,
+	const uint32_t when)
 {
 	uint32_t l_freq_mhz;
 	uint32_t l_freq_hz;

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -1557,7 +1557,10 @@ extern ADDAPI int ADDCALL hackrf_set_freq(hackrf_device* device, const uint64_t 
  * @return @ref HACKRF_SUCCESS on success or @ref hackrf_error variant
  * @ingroup configuration
  */
-extern ADDAPI int ADDCALL hackrf_set_freq_when(hackrf_device* device, const uint64_t freq_hz, const uint32_t when);
+extern ADDAPI int ADDCALL hackrf_set_freq_when(
+	hackrf_device* device,
+	const uint64_t freq_hz,
+	const uint32_t when);
 
 /**
  * Set the center frequency via explicit tuning

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -1543,6 +1543,23 @@ extern ADDAPI int ADDCALL hackrf_usb_api_version_read(
 extern ADDAPI int ADDCALL hackrf_set_freq(hackrf_device* device, const uint64_t freq_hz);
 
 /**
+ * Schedule a center frequency change at a specific point in the RX/TX stream. The "when" argument specifices this point in the stream, and its value corresponds to the number of bytes sent (resp. received) to (resp. from) since the beginning of the stream, modulo 2^32 (this corresponds to the m0_counter value of the firmware).
+ *
+ * NOTE: A maximum of one scheduled frequency change is supported at a time. Trying to schedule a frequency change when one is still pending will result in an usb stall.
+ * 
+ * Simple (auto) tuning via specifying a center frequency in Hz
+ * 
+ * This setting is not exact and depends on the PLL settings. Exact resolution is not determined, but the actual tuned frequency will be queryable in the future.
+ * 
+ * @param device device to tune
+ * @param freq_hz center frequency in Hz. Defaults to 900MHz. Should be in range 1-6000MHz, but 0-7250MHz is possible. The resolution is ~50Hz, I could not find the exact number.
+ * @param when sets the frequency when the m0 counter matches this value
+ * @return @ref HACKRF_SUCCESS on success or @ref hackrf_error variant
+ * @ingroup configuration
+ */
+extern ADDAPI int ADDCALL hackrf_set_freq_when(hackrf_device* device, const uint64_t freq_hz, const uint32_t when);
+
+/**
  * Set the center frequency via explicit tuning
  * 
  * Center frequency is set to \f$f_{center} = f_{IF} + k\cdot f_{LO}\f$ where \f$k\in\left\{-1; 0; 1\right\}\f$, depending on the value of @p path. See the documentation of @ref rf_path_filter for details


### PR DESCRIPTION
This implements the new API hackrf_set_freq_when() that schedules a center frequency change at a specific point in the RX/TX stream.

