### PR TITLE
Fix missing shared library version

### DIFF
--- a/host/libhackrf/src/CMakeLists.txt
+++ b/host/libhackrf/src/CMakeLists.txt
@@ -86,7 +86,7 @@ endfunction()
 # Dynamic library
 if(ENABLE_SHARED_LIB)
   add_library(hackrf SHARED hackrf.c)
-  set_target_properties(${libtarget} PROPERTIES
+  set_target_properties(hackrf PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR})
   libhackrf_common_settings(hackrf)


### PR DESCRIPTION
The libtarget variable isn't defined here (it's used in a helper function above). This caused libhackrf to be built and installed without a version number.

This fixes a change from #1586.