### PR TITLE
Disable some unreliable self-tests

### DIFF
--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -898,29 +898,6 @@ void cpu_clock_init(void)
 	CGU_BASE_SSP1_CLK =
 		CGU_BASE_SSP1_CLK_AUTOBLOCK(1) | CGU_BASE_SSP1_CLK_CLK_SEL(CGU_SRC_PLL1);
 
-#ifndef RAD1O
-	/* Enable 32kHz oscillator */
-	CREG_CREG0 &= ~(CREG_CREG0_PD32KHZ | CREG_CREG0_RESET32KHZ);
-	CREG_CREG0 |= CREG_CREG0_EN32KHZ;
-
-	/* Allow 1ms to start up. */
-	delay_us_at_mhz(1000, 204);
-
-	/* Use frequency monitor to check 32kHz oscillator is running. */
-	CGU_FREQ_MON = CGU_FREQ_MON_RCNT(511) | CGU_FREQ_MON_CLK_SEL(CGU_SRC_32K);
-	CGU_FREQ_MON |= CGU_FREQ_MON_MEAS_MASK;
-	while (CGU_FREQ_MON & CGU_FREQ_MON_MEAS_MASK)
-		;
-	uint32_t count =
-		(CGU_FREQ_MON & CGU_FREQ_MON_FCNT_MASK) >> CGU_FREQ_MON_FCNT_SHIFT;
-	// We should see a single count, because 511 cycles of the 12MHz internal
-	// RC oscillator corresponds to 1.39 cycles of the 32768Hz clock.
-	selftest.rtc_osc_ok = (count == 1);
-	if (!selftest.rtc_osc_ok) {
-		selftest.report.pass = false;
-	}
-#endif
-
 #if (defined JAWBREAKER || defined HACKRF_ONE || defined PRALINE)
 	/* Disable unused clocks */
 	/* Start with PLLs */

--- a/firmware/common/max2831.c
+++ b/firmware/common/max2831.c
@@ -66,26 +66,6 @@ static void max2831_init(max2831_driver_t* const drv)
 
 	/* Write default register values to chip. */
 	max2831_regs_commit(drv);
-
-	/* Disable lock detect output. */
-	set_MAX2831_LOCK_DETECT_OUTPUT_EN(drv, false);
-	max2831_regs_commit(drv);
-
-	// Read state of lock detect pin.
-	bool initial = gpio_read(drv->gpio_ld);
-
-	// Enable lock detect output.
-	set_MAX2831_LOCK_DETECT_OUTPUT_EN(drv, true);
-	max2831_regs_commit(drv);
-
-	// Read new state of lock detect pin.
-	bool new = gpio_read(drv->gpio_ld);
-
-	// If the pin state changed, we know our writes are working.
-	selftest.max2831_ld_test_ok = initial != new;
-	if (!selftest.max2831_ld_test_ok) {
-		selftest.report.pass = false;
-	}
 }
 
 /*

--- a/firmware/common/rffc5071.c
+++ b/firmware/common/rffc5071.c
@@ -81,11 +81,6 @@ void rffc5071_init(rffc5071_driver_t* const drv)
 	memcpy(drv->regs, rffc5071_regs_default, sizeof(drv->regs));
 	drv->regs_dirty = 0x7fffffff;
 
-	selftest.mixer_id = rffc5071_reg_read(drv, RFFC5071_READBACK_REG);
-	if ((selftest.mixer_id >> 3) != 2031) {
-		selftest.report.pass = false;
-	}
-
 	/* Write default register values to chip. */
 	rffc5071_regs_commit(drv);
 }

--- a/firmware/hackrf_usb/usb_api_selftest.c
+++ b/firmware/hackrf_usb/usb_api_selftest.c
@@ -60,12 +60,6 @@ void generate_selftest_report(void)
 	append(&s, &c, "Mixer: MAX2871, ID: ");
 	append(&s, &c, itoa(selftest.mixer_id, 10));
 	append(&s, &c, "\n");
-#else
-	append(&s, &c, "Mixer: RFFC5072, ID: ");
-	append(&s, &c, itoa(selftest.mixer_id >> 3, 10));
-	append(&s, &c, ", Rev: ");
-	append(&s, &c, itoa(selftest.mixer_id & 0x7, 10));
-	append(&s, &c, "\n");
 #endif
 	append(&s, &c, "Clock: Si5351");
 	append(&s, &c, ", Rev: ");
@@ -73,11 +67,7 @@ void generate_selftest_report(void)
 	append(&s, &c, ", readback: ");
 	append(&s, &c, selftest.si5351_readback_ok ? "OK" : "FAIL");
 	append(&s, &c, "\n");
-#ifdef PRALINE
-	append(&s, &c, "Transceiver: MAX2831, LD pin test: ");
-	append(&s, &c, selftest.max2831_ld_test_ok ? "PASS" : "FAIL");
-	append(&s, &c, "\n");
-#else
+#ifndef PRALINE
 	append(&s, &c, "Transceiver: ");
 	append(&s,
 	       &c,
@@ -93,11 +83,6 @@ void generate_selftest_report(void)
 		append(&s, &c, ", expected: 0x");
 		append(&s, &c, itoa(selftest.max283x_readback_expected_value, 10));
 	}
-	append(&s, &c, "\n");
-#endif
-#ifndef RAD1O
-	append(&s, &c, "32kHz oscillator: ");
-	append(&s, &c, selftest.rtc_osc_ok ? "PASS" : "FAIL");
 	append(&s, &c, "\n");
 #endif
 #ifdef PRALINE


### PR DESCRIPTION
RFFC5072, MAX2831 and (less often) 32 kHz self-tests intermittently fail. These failures tend to coincide with each other and are typically seen after a power cycle, not after a reset.

Removing these tests for now.