### PR TITLE
Fix zlp bug when request response length falls on a packet boundary.

### DIFF
--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -520,7 +520,7 @@ static void copy_setup(usb_setup_t* const dst, const volatile uint8_t* const src
 	dst->length_h = src[7];
 }
 
-void usb_endpoint_init(const usb_endpoint_t* const endpoint)
+void usb_endpoint_init(const usb_endpoint_t* const endpoint, const bool enable_zlp)
 {
 	usb_endpoint_flush(endpoint);
 
@@ -537,10 +537,15 @@ void usb_endpoint_init(const usb_endpoint_t* const endpoint)
 	// TODO: There are more capabilities to adjust based on the endpoint
 	// descriptor.
 	usb_queue_head_t* const qh = usb_queue_head(endpoint->address);
-	qh->capabilities = USB_QH_CAPABILITIES_MULT(0) | USB_QH_CAPABILITIES_ZLT |
+	qh->capabilities = USB_QH_CAPABILITIES_MULT(0) |
 		USB_QH_CAPABILITIES_MPL(max_packet_size) |
 		((transfer_type == USB_TRANSFER_TYPE_CONTROL) ? USB_QH_CAPABILITIES_IOS :
 								0);
+	if (enable_zlp) {
+		qh->capabilities &= ~USB_QH_CAPABILITIES_ZLT;
+	} else {
+		qh->capabilities |= USB_QH_CAPABILITIES_ZLT;
+	}
 	qh->current_dtd_pointer = 0;
 	qh->next_dtd_pointer = USB_TD_NEXT_DTD_POINTER_TERMINATE;
 	qh->total_bytes = USB_TD_DTD_TOKEN_TOTAL_BYTES(0) | USB_TD_DTD_TOKEN_MULTO(0);

--- a/firmware/common/usb.h
+++ b/firmware/common/usb.h
@@ -50,7 +50,7 @@ void usb_set_address_deferred(
 
 usb_endpoint_t* usb_endpoint_from_address(const uint_fast8_t endpoint_address);
 
-void usb_endpoint_init(const usb_endpoint_t* const endpoint);
+void usb_endpoint_init(const usb_endpoint_t* const endpoint, const bool enable_zlp);
 
 void usb_endpoint_stall(const usb_endpoint_t* const endpoint);
 

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -191,8 +191,8 @@ void usb_configuration_changed(usb_device_t* const device)
 		/* Configuration number equal 0 means usb bus reset. */
 		led_off(LED1);
 	}
-	usb_endpoint_init(&usb_endpoint_bulk_in);
-	usb_endpoint_init(&usb_endpoint_bulk_out);
+	usb_endpoint_init(&usb_endpoint_bulk_in, false);
+	usb_endpoint_init(&usb_endpoint_bulk_out, false);
 }
 
 void usb_set_descriptor_by_serial_number(void)
@@ -311,8 +311,8 @@ int main(void)
 	usb_queue_init(&usb_endpoint_bulk_out_queue);
 	usb_queue_init(&usb_endpoint_bulk_in_queue);
 
-	usb_endpoint_init(&usb_endpoint_control_out);
-	usb_endpoint_init(&usb_endpoint_control_in);
+	usb_endpoint_init(&usb_endpoint_control_out, false);
+	usb_endpoint_init(&usb_endpoint_control_in, true);
 
 	nvic_set_priority(NVIC_USB0_IRQ, 255);
 


### PR DESCRIPTION
Previously this bug did not occur as the size of `usb_endpoint_t`'s IN transfer buffer was set to 32 bytes and control packets are 64 bytes long.