### PR TITLE
Test RFFC5072 PLL lock during startup

### DIFF
--- a/firmware/common/rffc5071.h
+++ b/firmware/common/rffc5071.h
@@ -44,6 +44,7 @@ typedef struct {
 /* Initialize chip. Call _setup() externally, as it calls _init(). */
 extern void rffc5071_init(rffc5071_driver_t* const drv);
 extern void rffc5071_setup(rffc5071_driver_t* const drv);
+extern void rffc5071_lock_test(rffc5071_driver_t* const drv);
 
 /* Read a register via SPI. Save a copy to memory and return
  * value. Discard any uncommited changes and mark CLEAN. */
@@ -73,5 +74,6 @@ extern void rffc5071_set_gpo(rffc5071_driver_t* const drv, uint8_t);
 #ifdef PRALINE
 extern bool rffc5071_poll_ld(rffc5071_driver_t* const drv, uint8_t* prelock_state);
 #endif
+extern bool rffc5071_check_lock(rffc5071_driver_t* const drv);
 
 #endif // __RFFC5071_H

--- a/firmware/common/selftest.h
+++ b/firmware/common/selftest.h
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define NUM_LOCK_ATTEMPTS 3
+
 enum {
 	FAILED = 0,
 	PASSED = 1,
@@ -36,6 +38,9 @@ typedef uint8_t test_result_t;
 
 typedef struct {
 	uint16_t mixer_id;
+#ifndef RAD1O
+	bool mixer_locks[NUM_LOCK_ATTEMPTS];
+#endif
 #ifdef PRALINE
 	uint16_t max2831_mux_rssi_1;
 	uint16_t max2831_mux_temp;

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -338,6 +338,10 @@ int main(void)
 
 	rf_path_init(&rf_path);
 
+#ifndef RAD1O
+	rffc5071_lock_test(&mixer);
+#endif
+
 #ifdef PRALINE
 	fpga_if_xcvr_selftest();
 #endif

--- a/firmware/hackrf_usb/usb_api_selftest.c
+++ b/firmware/hackrf_usb/usb_api_selftest.c
@@ -83,6 +83,17 @@ void generate_selftest_report(void)
 	append(&s, &c, itoa(selftest.mixer_id >> 3, 10));
 	append(&s, &c, ", Rev: ");
 	append(&s, &c, itoa(selftest.mixer_id & 0x7, 10));
+	append(&s, &c, ", Locks: ");
+	bool lock;
+	for (int i = 0; i < NUM_LOCK_ATTEMPTS; i++) {
+		lock = selftest.mixer_locks[i];
+		append(&s, &c, itoa(lock, 2));
+	}
+	if (lock) {
+		append(&s, &c, " (PASS)");
+	} else {
+		append(&s, &c, " (FAIL)");
+	}
 	append(&s, &c, "\n");
 #endif
 	append(&s, &c, "Clock: Si5351");


### PR DESCRIPTION
Attempt to lock the RFFC5072 PLL to a 100MHz LO at startup, and check the lock detect bit after 1ms.

The test runs three times and passes if the last attempt is successful.

Normal output is:

`Mixer: RFFC5072, ID: 4416, Rev: 1, Locks: 111 (PASS)`

I have also seen the first attempt fail, which is indicated as:

`Mixer: RFFC5072, ID: 4416, Rev: 1, Locks: 011 (PASS)`

This is consistent with the behaviour seen in #1438.