### PR TITLE
Provide access to the larger SPI flash on Praline

### DIFF
--- a/firmware/common/w25q80bv.c
+++ b/firmware/common/w25q80bv.c
@@ -59,8 +59,13 @@ void w25q80bv_setup(w25q80bv_driver_t* const drv)
 	uint8_t device_id;
 
 	drv->page_len = 256U;
+#ifdef PRALINE
+	drv->num_pages = 16384U;
+	drv->num_bytes = 4194304U;
+#else
 	drv->num_pages = 4096U;
 	drv->num_bytes = 1048576U;
+#endif
 
 	drv->target_init(drv);
 

--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -1515,7 +1515,7 @@ int ADDCALL hackrf_spiflash_write(
 {
 	int result;
 
-	if (address > 0x0FFFFF) {
+	if ((address + length) > 0x400000) {
 		return HACKRF_ERROR_INVALID_PARAM;
 	}
 
@@ -1546,7 +1546,7 @@ int ADDCALL hackrf_spiflash_read(
 {
 	int result;
 
-	if (address > 0x0FFFFF) {
+	if ((address + length) > 0x400000) {
 		return HACKRF_ERROR_INVALID_PARAM;
 	}
 


### PR DESCRIPTION
The original 8Mbit/1MB SPI flash size is hardcoded in the firmware, libhackrf and `hackrf_spiflash`, which prevents use of the rest of the 32Mbit/4MB flash on Praline.

This PR does the following:
1. Makes the firmware aware of the increased `num_pages` and `num_bytes` when built with `PRALINE` defined.
2. Makes `hackrf_spiflash` check the board ID, and apply a 4MB rather than 1MB limit for `BOARD_ID_PRALINE`.
3. Updates the argument range checks in libhackrf to fail only if `(address + length) > 0x400000`.

I have gone for the simplest set of changes here rather than trying to generalise to any future hardware.