### PR TITLE
Fix mixer lock

### DIFF
--- a/firmware/common/rffc5071.c
+++ b/firmware/common/rffc5071.c
@@ -40,17 +40,17 @@
 #include <libopencm3/lpc43xx/scu.h>
 #include "hackrf_core.h"
 
-/* Default register values. */
+/* Default register values from vendor documentation or software. */
 static const uint16_t rffc5071_regs_default[RFFC5071_NUM_REGS] = {
-	0xbefa, /* 00 */
+	0xfffb, /* 00 */
 	0x4064, /* 01 */
 	0x9055, /* 02 */
 	0x2d02, /* 03 */
-	0xacbf, /* 04 */
-	0xacbf, /* 05 */
+	0xb0bf, /* 04 */
+	0xb0bf, /* 05 */
 	0x0028, /* 06 */
 	0x0028, /* 07 */
-	0xff00, /* 08 */
+	0xfc06, /* 08 */
 	0x8220, /* 09 */
 	0x0202, /* 0A */
 	0x0400, /* 0B */
@@ -60,7 +60,7 @@ static const uint16_t rffc5071_regs_default[RFFC5071_NUM_REGS] = {
 	0x1e84, /* 0F */
 	0x89d8, /* 10 */
 	0x9d00, /* 11 */
-	0x2a00, /* 12 */
+	0x2a80, /* 12 */
 	0x0000, /* 13 */
 	0x0000, /* 14 */
 	0x0000, /* 15 */


### PR DESCRIPTION
The RFFC5072 PLL can fail to lock for multiple reasons, resulting in incorrect and drifting frequency tuning.

One cause is enabling the part with frequency registers set to zero, something we've always done. Fixing this reduced the incidence of PLL lock failure on cold start. Another thing that reduced incidence of PLL lock failure on cold start is enabling reference oscillator standby. With both fixes together, I was no longer able to reproduce PLL lock failure on cold start.

Another cause is that the default registers recommended in the RFFC5072 documentation configure too short/aggressive warm-up and calibration parameters. Updated registers produced by the vendor's configuration software extend the tuning time and improve tuning reliability.