### PR TITLE
Toolchain 9.2.1 support fix

### DIFF
--- a/firmware/hackrf_usb/CMakeLists.txt
+++ b/firmware/hackrf_usb/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_command(
 	COMMAND ${CMAKE_OBJCOPY} 
 		-I binary
 		-O elf32-littlearm
-		-B armv7e-m
+		-B arm
 		--rename-section .data=.rom_only
 		"fpga.bin" ${PATH_PRALINE_FPGA_OBJ}
 	DEPENDS ${PATH_PRALINE_FPGA_BIN}


### PR DESCRIPTION
Added -B arm flag to firmware/hackrf_usb/CMakeLists.txt to support builds with v9.2.1 toolchains.