### PR TITLE
Rename `struct gpio_t` to `struct gpio` to distinguish from `gpio_t`

### DIFF
--- a/firmware/common/gpio.h
+++ b/firmware/common/gpio.h
@@ -25,7 +25,7 @@
 
 #include <stdbool.h>
 
-typedef const struct gpio_t* gpio_t;
+typedef const struct gpio* gpio_t;
 
 void gpio_init(void);
 void gpio_set(gpio_t gpio);

--- a/firmware/common/gpio_lpc.h
+++ b/firmware/common/gpio_lpc.h
@@ -32,7 +32,7 @@
  * register #defines and API declarations into separate header files.
  */
 
-typedef struct gpio_port_t {
+typedef struct gpio_port {
 	volatile uint32_t dir; /* +0x000 */
 	uint32_t _reserved0[31];
 	volatile uint32_t mask; /* +0x080 */
@@ -48,7 +48,7 @@ typedef struct gpio_port_t {
 	volatile uint32_t inv; /* +0x300 */
 } gpio_port_t;
 
-struct gpio_t {
+struct gpio {
 	const uint32_t mask;
 	gpio_port_t* const port;
 	volatile uint32_t* const gpio_w;

--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -52,7 +52,7 @@
 #include "gpio_lpc.h"
 
 /* GPIO Output PinMux */
-static struct gpio_t gpio_led[] = {
+static struct gpio gpio_led[] = {
 	GPIO(2, 1),
 	GPIO(2, 2),
 	GPIO(2, 8),
@@ -66,134 +66,134 @@ static struct gpio_t gpio_led[] = {
 
 // clang-format off
 #ifndef PRALINE
-static struct gpio_t gpio_1v8_enable        = GPIO(3,  6);
+static struct gpio gpio_1v8_enable        = GPIO(3,  6);
 #else
-static struct gpio_t gpio_1v2_enable        = GPIO(4,  7);
-static struct gpio_t gpio_3v3aux_enable_n 	= GPIO(5, 15);
+static struct gpio gpio_1v2_enable        = GPIO(4,  7);
+static struct gpio gpio_3v3aux_enable_n 	= GPIO(5, 15);
 #endif
 
 /* MAX283x GPIO (XCVR_CTL / CS_XCVR) PinMux */
 #ifdef PRALINE
-static struct gpio_t gpio_max283x_select    = GPIO(6, 28);
+static struct gpio gpio_max283x_select    = GPIO(6, 28);
 #else
-static struct gpio_t gpio_max283x_select    = GPIO(0, 15);
+static struct gpio gpio_max283x_select    = GPIO(0, 15);
 #endif
 
 /* MAX5864 SPI chip select (AD_CS / CS_AD) GPIO PinMux */
 #ifdef PRALINE
-static struct gpio_t gpio_max5864_select    = GPIO(6, 30);
+static struct gpio gpio_max5864_select    = GPIO(6, 30);
 #else
-static struct gpio_t gpio_max5864_select    = GPIO(2,  7);
+static struct gpio gpio_max5864_select    = GPIO(2,  7);
 #endif
 
 /* RFFC5071 GPIO serial interface PinMux */
 // #ifdef RAD1O
-// static struct gpio_t gpio_rffc5072_select   = GPIO(2, 13);
-// static struct gpio_t gpio_rffc5072_clock    = GPIO(5,  6);
-// static struct gpio_t gpio_rffc5072_data     = GPIO(3,  3);
-// static struct gpio_t gpio_rffc5072_reset    = GPIO(2, 14);
+// static struct gpio gpio_rffc5072_select   = GPIO(2, 13);
+// static struct gpio gpio_rffc5072_clock    = GPIO(5,  6);
+// static struct gpio gpio_rffc5072_data     = GPIO(3,  3);
+// static struct gpio gpio_rffc5072_reset    = GPIO(2, 14);
 // #endif
 
 /* RF supply (VAA) control */
 #ifdef HACKRF_ONE
-static struct gpio_t gpio_vaa_disable       = GPIO(2, 9);
+static struct gpio gpio_vaa_disable       = GPIO(2, 9);
 #endif
 #ifdef PRALINE
-static struct gpio_t gpio_vaa_disable       = GPIO(4, 1);
+static struct gpio gpio_vaa_disable       = GPIO(4, 1);
 #endif
 #ifdef RAD1O
-static struct gpio_t gpio_vaa_enable        = GPIO(2, 9);
+static struct gpio gpio_vaa_enable        = GPIO(2, 9);
 #endif
 
-static struct gpio_t gpio_w25q80bv_hold     = GPIO(1, 14);
-static struct gpio_t gpio_w25q80bv_wp       = GPIO(1, 15);
-static struct gpio_t gpio_w25q80bv_select   = GPIO(5, 11);
+static struct gpio gpio_w25q80bv_hold     = GPIO(1, 14);
+static struct gpio gpio_w25q80bv_wp       = GPIO(1, 15);
+static struct gpio gpio_w25q80bv_select   = GPIO(5, 11);
 
 /* RF switch control */
 #ifdef HACKRF_ONE
-static struct gpio_t gpio_hp                = GPIO(2,  0);
-static struct gpio_t gpio_lp                = GPIO(2, 10);
-static struct gpio_t gpio_tx_mix_bp         = GPIO(2, 11);
-static struct gpio_t gpio_no_mix_bypass     = GPIO(1,  0);
-static struct gpio_t gpio_rx_mix_bp         = GPIO(2, 12);
-static struct gpio_t gpio_tx_amp            = GPIO(2, 15);
-static struct gpio_t gpio_tx                = GPIO(5, 15);
-static struct gpio_t gpio_mix_bypass        = GPIO(5, 16);
-static struct gpio_t gpio_rx                = GPIO(5,  5);
-static struct gpio_t gpio_no_tx_amp_pwr     = GPIO(3,  5);
-static struct gpio_t gpio_amp_bypass        = GPIO(0, 14);
-static struct gpio_t gpio_rx_amp            = GPIO(1, 11);
-static struct gpio_t gpio_no_rx_amp_pwr     = GPIO(1, 12);
+static struct gpio gpio_hp                = GPIO(2,  0);
+static struct gpio gpio_lp                = GPIO(2, 10);
+static struct gpio gpio_tx_mix_bp         = GPIO(2, 11);
+static struct gpio gpio_no_mix_bypass     = GPIO(1,  0);
+static struct gpio gpio_rx_mix_bp         = GPIO(2, 12);
+static struct gpio gpio_tx_amp            = GPIO(2, 15);
+static struct gpio gpio_tx                = GPIO(5, 15);
+static struct gpio gpio_mix_bypass        = GPIO(5, 16);
+static struct gpio gpio_rx                = GPIO(5,  5);
+static struct gpio gpio_no_tx_amp_pwr     = GPIO(3,  5);
+static struct gpio gpio_amp_bypass        = GPIO(0, 14);
+static struct gpio gpio_rx_amp            = GPIO(1, 11);
+static struct gpio gpio_no_rx_amp_pwr     = GPIO(1, 12);
 #endif
 #ifdef RAD1O
-static struct gpio_t gpio_tx_rx_n           = GPIO(1,  11);
-static struct gpio_t gpio_tx_rx             = GPIO(0,  14);
-static struct gpio_t gpio_by_mix            = GPIO(1,  12);
-static struct gpio_t gpio_by_mix_n          = GPIO(2,  10);
-static struct gpio_t gpio_by_amp            = GPIO(1,  0);
-static struct gpio_t gpio_by_amp_n          = GPIO(5,  5);
-static struct gpio_t gpio_mixer_en          = GPIO(5,  16);
-static struct gpio_t gpio_low_high_filt     = GPIO(2,  11);
-static struct gpio_t gpio_low_high_filt_n   = GPIO(2,  12);
-static struct gpio_t gpio_tx_amp            = GPIO(2,  15);
-static struct gpio_t gpio_rx_lna            = GPIO(5,  15);
+static struct gpio gpio_tx_rx_n           = GPIO(1,  11);
+static struct gpio gpio_tx_rx             = GPIO(0,  14);
+static struct gpio gpio_by_mix            = GPIO(1,  12);
+static struct gpio gpio_by_mix_n          = GPIO(2,  10);
+static struct gpio gpio_by_amp            = GPIO(1,  0);
+static struct gpio gpio_by_amp_n          = GPIO(5,  5);
+static struct gpio gpio_mixer_en          = GPIO(5,  16);
+static struct gpio gpio_low_high_filt     = GPIO(2,  11);
+static struct gpio gpio_low_high_filt_n   = GPIO(2,  12);
+static struct gpio gpio_tx_amp            = GPIO(2,  15);
+static struct gpio gpio_rx_lna            = GPIO(5,  15);
 #endif
 #ifdef PRALINE
-static struct gpio_t gpio_tx_en				= GPIO(3,  4);
-static struct gpio_t gpio_mix_en_n			= GPIO(3,  2);
-static struct gpio_t gpio_mix_en_n_r1_0		= GPIO(5,  6);
-static struct gpio_t gpio_lpf_en			= GPIO(4,  8);
-static struct gpio_t gpio_rf_amp_en			= GPIO(4,  9);
-static struct gpio_t gpio_ant_bias_en_n		= GPIO(1, 12);
+static struct gpio gpio_tx_en				= GPIO(3,  4);
+static struct gpio gpio_mix_en_n			= GPIO(3,  2);
+static struct gpio gpio_mix_en_n_r1_0		= GPIO(5,  6);
+static struct gpio gpio_lpf_en			= GPIO(4,  8);
+static struct gpio gpio_rf_amp_en			= GPIO(4,  9);
+static struct gpio gpio_ant_bias_en_n		= GPIO(1, 12);
 #endif
 
 /* CPLD JTAG interface GPIO pins, FPGA config pins in Praline */
-static struct gpio_t gpio_cpld_tck          = GPIO(3,  0);
+static struct gpio gpio_cpld_tck          = GPIO(3,  0);
 #ifdef PRALINE
-static struct gpio_t gpio_fpga_cfg_creset	= GPIO(2, 11);
-static struct gpio_t gpio_fpga_cfg_cdone	= GPIO(5, 14);
-static struct gpio_t gpio_fpga_cfg_spi_cs	= GPIO(2, 10);
+static struct gpio gpio_fpga_cfg_creset	= GPIO(2, 11);
+static struct gpio gpio_fpga_cfg_cdone	= GPIO(5, 14);
+static struct gpio gpio_fpga_cfg_spi_cs	= GPIO(2, 10);
 #else
-static struct gpio_t gpio_cpld_tdo          = GPIO(5, 18);
+static struct gpio gpio_cpld_tdo          = GPIO(5, 18);
 #if (defined HACKRF_ONE || defined RAD1O)
-static struct gpio_t gpio_cpld_tms          = GPIO(3,  4);
-static struct gpio_t gpio_cpld_tdi          = GPIO(3,  1);
+static struct gpio gpio_cpld_tms          = GPIO(3,  4);
+static struct gpio gpio_cpld_tdi          = GPIO(3,  1);
 #else
-static struct gpio_t gpio_cpld_tms          = GPIO(3,  1);
-static struct gpio_t gpio_cpld_tdi          = GPIO(3,  4);
+static struct gpio gpio_cpld_tms          = GPIO(3,  1);
+static struct gpio gpio_cpld_tdi          = GPIO(3,  4);
 #endif
 #endif
 
 #if (defined HACKRF_ONE || defined PRALINE)
-static struct gpio_t gpio_cpld_pp_tms       = GPIO(1,  1);
-static struct gpio_t gpio_cpld_pp_tdo       = GPIO(1,  8);
+static struct gpio gpio_cpld_pp_tms       = GPIO(1,  1);
+static struct gpio gpio_cpld_pp_tdo       = GPIO(1,  8);
 #endif
 
 /* other CPLD interface GPIO pins */
 #ifndef PRALINE
-static struct gpio_t gpio_trigger_enable    = GPIO(5, 12);
+static struct gpio gpio_trigger_enable    = GPIO(5, 12);
 #endif
-static struct gpio_t gpio_q_invert          = GPIO(0, 13);
+static struct gpio gpio_q_invert          = GPIO(0, 13);
 
 /* HackRF One r9 */
 #ifdef HACKRF_ONE
-static struct gpio_t gpio_h1r9_rx             = GPIO(0, 7);
-static struct gpio_t gpio_h1r9_1v8_enable     = GPIO(2, 9);
-static struct gpio_t gpio_h1r9_vaa_disable    = GPIO(3, 6);
-static struct gpio_t gpio_h1r9_trigger_enable = GPIO(5, 5);
+static struct gpio gpio_h1r9_rx             = GPIO(0, 7);
+static struct gpio gpio_h1r9_1v8_enable     = GPIO(2, 9);
+static struct gpio gpio_h1r9_vaa_disable    = GPIO(3, 6);
+static struct gpio gpio_h1r9_trigger_enable = GPIO(5, 5);
 #endif
 
 #ifdef PRALINE
-static struct gpio_t gpio_p2_ctrl0     = GPIO(7, 3);
-static struct gpio_t gpio_p2_ctrl1     = GPIO(7, 4);
-static struct gpio_t gpio_p1_ctrl0     = GPIO(0, 14);
-static struct gpio_t gpio_p1_ctrl1     = GPIO(5, 16);
-static struct gpio_t gpio_p1_ctrl2     = GPIO(3, 5);
-static struct gpio_t gpio_clkin_ctrl   = GPIO(0, 15);
-static struct gpio_t gpio_aa_en        = GPIO(1, 7);
-static struct gpio_t gpio_trigger_in   = GPIO(6, 26);
-static struct gpio_t gpio_trigger_out  = GPIO(5, 6);
-static struct gpio_t gpio_pps_out      = GPIO(5, 5);
+static struct gpio gpio_p2_ctrl0     = GPIO(7, 3);
+static struct gpio gpio_p2_ctrl1     = GPIO(7, 4);
+static struct gpio gpio_p1_ctrl0     = GPIO(0, 14);
+static struct gpio gpio_p1_ctrl1     = GPIO(5, 16);
+static struct gpio gpio_p1_ctrl2     = GPIO(3, 5);
+static struct gpio gpio_clkin_ctrl   = GPIO(0, 15);
+static struct gpio gpio_aa_en        = GPIO(1, 7);
+static struct gpio gpio_trigger_in   = GPIO(6, 26);
+static struct gpio gpio_trigger_out  = GPIO(5, 6);
+static struct gpio gpio_pps_out      = GPIO(5, 5);
 #endif
 // clang-format on
 
@@ -248,10 +248,10 @@ const ssp_config_t ssp_config_max283x = {
 	.gpio_select = &gpio_max283x_select,
 };
 
-static struct gpio_t gpio_max2831_enable = GPIO(7, 1);
-static struct gpio_t gpio_max2831_rx_enable = GPIO(7, 2);
-static struct gpio_t gpio_max2831_rxhp = GPIO(6, 29);
-static struct gpio_t gpio_max2831_ld = GPIO(4, 11);
+static struct gpio gpio_max2831_enable = GPIO(7, 1);
+static struct gpio gpio_max2831_rx_enable = GPIO(7, 2);
+static struct gpio gpio_max2831_rxhp = GPIO(6, 29);
+static struct gpio gpio_max2831_ld = GPIO(4, 11);
 
 max2831_driver_t max283x = {
 	.bus = &spi_bus_ssp1,

--- a/firmware/common/max283x.c
+++ b/firmware/common/max283x.c
@@ -33,13 +33,13 @@
 
 extern spi_bus_t spi_bus_ssp1;
 #ifdef PRALINE
-static struct gpio_t gpio_max2837_enable = GPIO(6, 29);
-static struct gpio_t gpio_max2837_rx_enable = GPIO(3, 3);
-static struct gpio_t gpio_max2837_tx_enable = GPIO(3, 2);
+static struct gpio gpio_max2837_enable = GPIO(6, 29);
+static struct gpio gpio_max2837_rx_enable = GPIO(3, 3);
+static struct gpio gpio_max2837_tx_enable = GPIO(3, 2);
 #else
-static struct gpio_t gpio_max2837_enable = GPIO(2, 6);
-static struct gpio_t gpio_max2837_rx_enable = GPIO(2, 5);
-static struct gpio_t gpio_max2837_tx_enable = GPIO(2, 4);
+static struct gpio gpio_max2837_enable = GPIO(2, 6);
+static struct gpio gpio_max2837_rx_enable = GPIO(2, 5);
+static struct gpio gpio_max2837_tx_enable = GPIO(2, 4);
 #endif
 
 max2837_driver_t max2837 = {

--- a/firmware/common/mixer.c
+++ b/firmware/common/mixer.c
@@ -28,25 +28,25 @@
 /* RFFC5071 GPIO serial interface PinMux */
 // clang-format off
 #if (defined JAWBREAKER || defined HACKRF_ONE)
-static struct gpio_t gpio_rffc5072_select = GPIO(2, 13);
-static struct gpio_t gpio_rffc5072_clock  = GPIO(5,  6);
-static struct gpio_t gpio_rffc5072_data   = GPIO(3,  3);
-static struct gpio_t gpio_rffc5072_reset  = GPIO(2, 14);
+static struct gpio gpio_rffc5072_select = GPIO(2, 13);
+static struct gpio gpio_rffc5072_clock  = GPIO(5,  6);
+static struct gpio gpio_rffc5072_data   = GPIO(3,  3);
+static struct gpio gpio_rffc5072_reset  = GPIO(2, 14);
 #endif
 #ifdef RAD1O
-static struct gpio_t gpio_vco_ce        = GPIO(2, 13);
-static struct gpio_t gpio_vco_sclk      = GPIO(5,  6);
-static struct gpio_t gpio_vco_sdata     = GPIO(3,  3);
-static struct gpio_t gpio_vco_le        = GPIO(2, 14);
-static struct gpio_t gpio_vco_mux       = GPIO(5, 25);
-static struct gpio_t gpio_synt_rfout_en = GPIO(3,  5);
+static struct gpio gpio_vco_ce        = GPIO(2, 13);
+static struct gpio gpio_vco_sclk      = GPIO(5,  6);
+static struct gpio gpio_vco_sdata     = GPIO(3,  3);
+static struct gpio gpio_vco_le        = GPIO(2, 14);
+static struct gpio gpio_vco_mux       = GPIO(5, 25);
+static struct gpio gpio_synt_rfout_en = GPIO(3,  5);
 #endif
 #ifdef PRALINE
-static struct gpio_t gpio_rffc5072_select = GPIO(2, 13);
-static struct gpio_t gpio_rffc5072_clock  = GPIO(5, 18);
-static struct gpio_t gpio_rffc5072_data   = GPIO(4, 14);
-static struct gpio_t gpio_rffc5072_reset  = GPIO(2, 14);
-static struct gpio_t gpio_rffc5072_ld     = GPIO(6, 25);
+static struct gpio gpio_rffc5072_select = GPIO(2, 13);
+static struct gpio gpio_rffc5072_clock  = GPIO(5, 18);
+static struct gpio gpio_rffc5072_data   = GPIO(4, 14);
+static struct gpio gpio_rffc5072_reset  = GPIO(2, 14);
+static struct gpio gpio_rffc5072_ld     = GPIO(6, 25);
 #endif
 // clang-format on
 

--- a/firmware/common/operacake.c
+++ b/firmware/common/operacake.c
@@ -393,7 +393,7 @@ uint16_t gpio_test(uint8_t address)
 	scu_pinmux(SCU_PINMUX_GPIO3_14, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 	scu_pinmux(SCU_PINMUX_GPIO3_15, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 
-	static struct gpio_t gpio_pins[] = {
+	static struct gpio gpio_pins[] = {
 		GPIO(3, 8),  // u1ctrl   IO2
 		GPIO(3, 14), // u3ctrl0  IO3
 		GPIO(3, 15), // u3ctrl1  IO4

--- a/firmware/common/platform_detect.c
+++ b/firmware/common/platform_detect.c
@@ -31,10 +31,10 @@
 static board_id_t platform = BOARD_ID_UNDETECTED;
 static board_rev_t revision = BOARD_REV_UNDETECTED;
 
-static struct gpio_t gpio2_9_on_P5_0 = GPIO(2, 9);
-static struct gpio_t gpio3_6_on_P6_10 = GPIO(3, 6);
-static struct gpio_t gpio3_4_on_P6_5 = GPIO(3, 4);
-static struct gpio_t gpio2_6_on_P4_6 = GPIO(2, 6);
+static struct gpio gpio2_9_on_P5_0 = GPIO(2, 9);
+static struct gpio gpio3_6_on_P6_10 = GPIO(3, 6);
+static struct gpio gpio3_4_on_P6_5 = GPIO(3, 4);
+static struct gpio gpio2_6_on_P4_6 = GPIO(2, 6);
 
 #define P5_0_PUP  (1 << 0)
 #define P5_0_PDN  (1 << 1)
@@ -61,9 +61,9 @@ static struct gpio_t gpio2_6_on_P4_6 = GPIO(2, 6);
  * hardware detection failure, but three LEDs are flashed if CPLD/FPGA configuration
  * fails.
  */
-static struct gpio_t gpio_led1 = GPIO(2, 1);
-static struct gpio_t gpio_led2 = GPIO(2, 2);
-static struct gpio_t gpio_led3 = GPIO(2, 8);
+static struct gpio gpio_led1 = GPIO(2, 1);
+static struct gpio gpio_led2 = GPIO(2, 2);
+static struct gpio gpio_led3 = GPIO(2, 8);
 
 /*
  * Starting with r6, HackRF One has pin straps on ADC pins that indicate

--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -35,15 +35,15 @@ static void portapack_sleep_milliseconds(const uint32_t milliseconds)
 }
 
 // clang-format off
-static struct gpio_t gpio_io_stbx = GPIO(5,  0); /* P2_0 */
-static struct gpio_t gpio_addr    = GPIO(5,  1); /* P2_1 */
+static struct gpio gpio_io_stbx = GPIO(5,  0); /* P2_0 */
+static struct gpio gpio_addr    = GPIO(5,  1); /* P2_1 */
 __attribute__((unused))
-static struct gpio_t gpio_lcd_te  = GPIO(5,  3); /* P2_3 */
+static struct gpio gpio_lcd_te  = GPIO(5,  3); /* P2_3 */
 __attribute__((unused))
-static struct gpio_t gpio_unused  = GPIO(5,  7); /* P2_8 */
-static struct gpio_t gpio_lcd_rdx = GPIO(5,  4); /* P2_4 */
-static struct gpio_t gpio_lcd_wrx = GPIO(1, 10); /* P2_9 */
-static struct gpio_t gpio_dir     = GPIO(1, 13); /* P2_13 */
+static struct gpio gpio_unused  = GPIO(5,  7); /* P2_8 */
+static struct gpio gpio_lcd_rdx = GPIO(5,  4); /* P2_4 */
+static struct gpio gpio_lcd_wrx = GPIO(1, 10); /* P2_9 */
+static struct gpio gpio_dir     = GPIO(1, 13); /* P2_13 */
 
 // clang-format on
 

--- a/firmware/common/rad1o/display.c
+++ b/firmware/common/rad1o/display.c
@@ -17,9 +17,9 @@ static void delayms(const uint32_t milliseconds)
 	delay(milliseconds * 40800);
 }
 
-static struct gpio_t gpio_lcd_cs = GPIO(4, 12);    /* P9_0 */
-static struct gpio_t gpio_lcd_bl_en = GPIO(0, 8);  /* P1_1 */
-static struct gpio_t gpio_lcd_reset = GPIO(5, 17); /* P9_4 */
+static struct gpio gpio_lcd_cs = GPIO(4, 12);    /* P9_0 */
+static struct gpio gpio_lcd_bl_en = GPIO(0, 8);  /* P1_1 */
+static struct gpio gpio_lcd_reset = GPIO(5, 17); /* P9_4 */
 
 /**************************************************************************/
 /* Utility routines to manage nokia display */

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -99,7 +99,7 @@
  * In HackRF One r9 this control signal has been moved to the microcontroller.
  */
 
-static struct gpio_t gpio_h1r9_no_ant_pwr = GPIO(2, 4);
+static struct gpio gpio_h1r9_no_ant_pwr = GPIO(2, 4);
 
 static void switchctrl_set_hackrf_one(rf_path_t* const rf_path, uint8_t ctrl)
 {

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -30,9 +30,9 @@
 
 /* HackRF One r9 clock control */
 // clang-format off
-static struct gpio_t gpio_h1r9_clkin_en   = GPIO(5, 15);
-static struct gpio_t gpio_h1r9_clkout_en  = GPIO(0,  9);
-static struct gpio_t gpio_h1r9_mcu_clk_en = GPIO(0,  8);
+static struct gpio gpio_h1r9_clkin_en   = GPIO(5, 15);
+static struct gpio gpio_h1r9_clkout_en  = GPIO(0,  9);
+static struct gpio gpio_h1r9_mcu_clk_en = GPIO(0,  8);
 // clang-format on
 
 #include <stdbool.h>

--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -35,9 +35,9 @@
 
 #ifdef HACKRF_ONE
 	#include "gpio_lpc.h"
-static struct gpio_t gpio_h1r9_clkout_en = GPIO(0, 9);
-static struct gpio_t gpio_h1r9_mcu_clk_en = GPIO(0, 8);
-static struct gpio_t gpio_h1r9_rx = GPIO(0, 7);
+static struct gpio gpio_h1r9_clkout_en = GPIO(0, 9);
+static struct gpio gpio_h1r9_mcu_clk_en = GPIO(0, 8);
+static struct gpio gpio_h1r9_rx = GPIO(0, 7);
 #endif
 
 usb_request_status_t usb_vendor_request_read_board_id(


### PR DESCRIPTION
We've been using `gpio_t` as both the name of a `struct`, and a typedef for a pointer to that `struct`.

In C that's possible because `struct gpio_t` names a different type from `gpio_t` , but it's confusing, and causes problems when trying to include the types elsewhere.