### PR TITLE
Add `-Wold-style-definition` to compiler flags

### DIFF
--- a/firmware/hackrf-common.cmake
+++ b/firmware/hackrf-common.cmake
@@ -92,7 +92,7 @@ SET(LDSCRIPT_M4_RAM "-T${PATH_HACKRF_FIRMWARE_COMMON}/${MCU_PARTNO}_M4_memory.ld
 
 SET(LDSCRIPT_M0 "-T${PATH_HACKRF_FIRMWARE_COMMON}/LPC43xx_M0_memory.ld -Tlibopencm3_lpc43xx_m0.ld")
 
-SET(CFLAGS_COMMON "-Os -g3 -Wall -Wextra -Wstrict-prototypes ${HACKRF_OPTS} -fno-common -MD")
+SET(CFLAGS_COMMON "-Os -g3 -Wall -Wextra -Wstrict-prototypes -Wold-style-definition ${HACKRF_OPTS} -fno-common -MD")
 SET(LDFLAGS_COMMON "-nostartfiles -Wl,--gc-sections")
 
 if(V STREQUAL "1")


### PR DESCRIPTION
Followup to #1667.

This will catch the case where someone defines a C function with an empty argument list, e.g:

```
firmware/common/operacake_sctimer.c:58:6: warning: old-style function definition [-Wold-style-definition]
   58 | void operacake_sctimer_init()
      |      ^~~~~~~~~~~~~~~~~~~~~~
```