### PR TITLE
Add `nonstring` attribute to firmware_info magic field

### DIFF
--- a/firmware/common/firmware_info.h
+++ b/firmware/common/firmware_info.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 struct firmware_info_t {
-	char magic[8];
+	__attribute__((nonstring)) char magic[8];
 	uint16_t struct_version;
 	uint16_t dfu_mode;
 	uint32_t supported_platform;


### PR DESCRIPTION
Fixes compiler warnings such as:

```
firmware_info.c:49:18: warning: initializer-string for array of 'char' truncates NUL terminator but
destination lacks 'nonstring' attribute (9 chars into 8 available) [-Wunterminated-string-initialization]
   49 |         .magic = "HACKRFFW",
      |                  ^~~~~~~~~~
```