### PR TITLE
Rename gpio.not to gpio.inv to avoid conflict with C++ keyword

### DIFF
--- a/firmware/common/gpio_lpc.c
+++ b/firmware/common/gpio_lpc.c
@@ -43,7 +43,7 @@ void gpio_clear(gpio_t gpio)
 
 void gpio_toggle(gpio_t gpio)
 {
-	gpio->port->not = gpio->mask;
+	gpio->port->inv = gpio->mask;
 }
 
 void gpio_output(gpio_t gpio)

--- a/firmware/common/gpio_lpc.h
+++ b/firmware/common/gpio_lpc.h
@@ -45,7 +45,7 @@ typedef struct gpio_port_t {
 	uint32_t _reserved4[31];
 	volatile uint32_t clr; /* +0x280 */
 	uint32_t _reserved5[31];
-	volatile uint32_t not ; /* +0x300 */
+	volatile uint32_t inv; /* +0x300 */
 } gpio_port_t;
 
 struct gpio_t {


### PR DESCRIPTION
In C++, `not` is a keyword.