### PR TITLE
Change Praline CLKIN default to P1_CLKIN

### DIFF
--- a/ci-scripts/hackrf_pro_test.py
+++ b/ci-scripts/hackrf_pro_test.py
@@ -663,9 +663,6 @@ class HackRF:
             self.rf_test_cases = praline_r110_rf_test_cases
 
     def clkin(self):
-        if self.name == "EUT" and self.id == "5":
-            debug = subprocess.run([self.bin_dir + "/hackrf_debug", "-d", self.serial,
-                                    "-C", "0"])
         command = subprocess.run([self.bin_dir + "/hackrf_clock", "-i", "-d",
             self.serial], capture_output=True, encoding="utf-8",
             timeout=TIMEOUT)

--- a/docs/source/external_clock_interface.rst
+++ b/docs/source/external_clock_interface.rst
@@ -9,12 +9,18 @@ HackRF Pro
 
 HackRF Pro has two configurable SMA ports, P1 and P2. By default, P1 is configured as CLKIN and P2 as CLKOUT. The default behaviour of these signals is as described for HackRF One below.
 
+A second CLKIN signal is available on header P22 pin 2. Unlike HackRF One, HackRF Pro's P22_CLKIN is a separate signal from P1_CLKIN. To enable P22_CLKIN instead of P1_CLKIN use ``hackrf_clock -c p22``.
+
+Various internal signals can be connected to P1 or P2 instead of the default CLKIN and CLKOUT signals. Use ``hackrf_clock -1`` or ``hackrf_clock -2`` to select a different signal.
+
 HackRF One
 ~~~~~~~~~~
 
-HackRF One produces a 10 MHz clock signal on CLKOUT. The signal is a 3.3 V, 10 MHz square wave intended for a high impedance load.
+HackRF One produces a 10 MHz clock signal on the CLKOUT SMA port. The signal is a 3.3 V, 10 MHz square wave intended for a high impedance load.
 
-The CLKIN port on HackRF One is a high impedance input that expects 3.3 V square wave at 10 MHz. Do not exceed 3.3 V or drop below 0 V on this input. Do not connect a clock signal at a frequency other than 10 MHz (unless you modify the firmware to support this). You may directly connect the CLKOUT port of one HackRF One to the CLKIN port of another HackRF One.
+The CLKIN SMA port on HackRF One is a high impedance input that expects 3.3 V square wave at 10 MHz. Do not exceed 3.3 V or drop below 0 V on this input. Do not connect a clock signal at a frequency other than 10 MHz (unless you modify the firmware to support this). You may directly connect the CLKOUT port of one HackRF One to the CLKIN port of another HackRF.
+
+The CLKIN signal is also connected to header P22 pin 2. Unlike HackRF Pro, HackRF One has only one CLKIN signal shared between P22 pin 2 and the CLKIN port. Do not connect input signals to both CLKIN and P22 pin 2 simultaneously.
 
 HackRF One uses CLKIN instead of the internal crystal when a clock signal is detected on CLKIN. The switch to or from CLKIN only happens when a transmit or receive operation begins.
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -185,7 +185,7 @@ void pins_shutdown(void)
 		p2_ctrl_set(P2_SIGNAL_CLK3);
 		p1_ctrl_set(P1_SIGNAL_CLKIN);
 		narrowband_filter_set(0);
-		clkin_ctrl_set(CLKIN_SIGNAL_P22);
+		clkin_ctrl_set(CLKIN_SIGNAL_P1);
 
 		gpio_output(gpio->p2_ctrl0);
 		gpio_output(gpio->p2_ctrl1);

--- a/host/hackrf-tools/src/hackrf_clock.c
+++ b/host/hackrf-tools/src/hackrf_clock.c
@@ -103,6 +103,19 @@ int parse_p2_ctrl_signal(char* s, enum p2_ctrl_signal* const signal)
 	return HACKRF_SUCCESS;
 }
 
+int parse_clkin_ctrl_signal(char* s, enum clkin_ctrl_signal* const signal)
+{
+	if (strcasecmp("p1", s) == 0) {
+		*signal = CLKIN_SIGNAL_P1;
+	} else if (strcasecmp("p22", s) == 0) {
+		*signal = CLKIN_SIGNAL_P22;
+	} else {
+		fprintf(stderr, "Invalid signal '%s'\n", s);
+		return HACKRF_ERROR_INVALID_PARAM;
+	}
+	return HACKRF_SUCCESS;
+}
+
 int si5351c_read_register(hackrf_device* device, const uint16_t register_number)
 {
 	uint16_t register_value;
@@ -295,6 +308,8 @@ static void usage()
 	printf("\tone of: clkin, trigger_in, trigger_out, p22_clkin, pps_out, aux_clk1, aux_clk2, off\n");
 	printf("\t-2, --p2 <signal>: select the signal for the HackRF Pro P2 SMA connector (default: clkout)\n");
 	printf("\tone of: clkout, trigger_in, trigger_out\n");
+	printf("\t-c, --clkin-ctrl <signal>: select the HackRF Pro CLKIN signal (default: p1)\n");
+	printf("\tone of: p1, p22\n");
 	printf("\t-d, --device <serial_number>: Serial number of desired HackRF.\n");
 	printf("\nExamples:\n");
 	printf("\thackrf_clock -r 3 : prints settings for CLKOUT\n");
@@ -308,6 +323,7 @@ static struct option long_options[] = {
 	{"clkout", required_argument, 0, 'o'},
 	{"p1", required_argument, 0, '1'},
 	{"p2", required_argument, 0, '2'},
+	{"clkin-ctrl", required_argument, 0, 'c'},
 	{"device", required_argument, 0, 'd'},
 	{0, 0, 0, 0},
 };
@@ -324,8 +340,10 @@ int main(int argc, char** argv)
 	uint8_t clkin_status;
 	bool p1_ctrl = false;
 	bool p2_ctrl = false;
+	bool clkin_ctrl = false;
 	enum p1_ctrl_signal p1_signal = P1_SIGNAL_CLKIN;
 	enum p2_ctrl_signal p2_signal = P2_SIGNAL_CLK3;
+	enum clkin_ctrl_signal clkin_signal = CLKIN_SIGNAL_P1;
 	const char* serial_number = NULL;
 
 	int result = hackrf_init();
@@ -339,7 +357,7 @@ int main(int argc, char** argv)
 	while ((opt = getopt_long(
 			argc,
 			argv,
-			"r:aio:1:2:d:h?",
+			"r:aio:1:2:c:d:h?",
 			long_options,
 			&option_index)) != EOF) {
 		switch (opt) {
@@ -371,6 +389,11 @@ int main(int argc, char** argv)
 			result = parse_p2_ctrl_signal(optarg, &p2_signal);
 			break;
 
+		case 'c':
+			clkin_ctrl = true;
+			result = parse_clkin_ctrl_signal(optarg, &clkin_signal);
+			break;
+
 		case 'd':
 			serial_number = optarg;
 			break;
@@ -394,7 +417,7 @@ int main(int argc, char** argv)
 		}
 	}
 
-	if (!clkin && !clkout && !read && !p1_ctrl && !p2_ctrl) {
+	if (!clkin && !clkout && !read && !p1_ctrl && !p2_ctrl && !clkin_ctrl) {
 		fprintf(stderr, "An operation must be specified.\n");
 		usage();
 		return EXIT_FAILURE;
@@ -454,6 +477,16 @@ int main(int argc, char** argv)
 		result = hackrf_set_p2_ctrl(device, p2_signal);
 		if (result) {
 			printf("hackrf_set_p2_ctrl() failed: %s (%d)\n",
+			       hackrf_error_name(result),
+			       result);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (clkin_ctrl) {
+		result = hackrf_set_clkin_ctrl(device, clkin_signal);
+		if (result != HACKRF_SUCCESS) {
+			printf("hackrf_set_clkin_ctrl() failed: %s (%d)\n",
 			       hackrf_error_name(result),
 			       result);
 			return EXIT_FAILURE;


### PR DESCRIPTION
Enable P1_CLKIN by default and disconnect P22_CLKIN by default.

Close #1624 

[edit: Originally this changed the P1 default from P1_CLKIN to P22_CLKIN, matching the default behavior of HackRF One. See the following discussion.]