### PR TITLE
Replace include guards with `#pragma once`

### DIFF
--- a/firmware/common/adc.h
+++ b/firmware/common/adc.h
@@ -19,12 +19,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __ADC_H__
-#define __ADC_H__
+#pragma once
 
 #include <stdint.h>
 
 uint16_t adc_read(uint8_t pin);
 void adc_off(void);
-
-#endif // __ADC_H__

--- a/firmware/common/bitband.h
+++ b/firmware/common/bitband.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __BITBAND_H__
-#define __BITBAND_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -37,5 +36,3 @@ void peripheral_bitband_clear(
 uint32_t peripheral_bitband_get(
 	volatile void* const peripheral_address,
 	const uint_fast8_t bit_number);
-
-#endif //__BITBAND_H__

--- a/firmware/common/clkin.h
+++ b/firmware/common/clkin.h
@@ -19,12 +19,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __CLKIN_H__
-#define __CLKIN_H__
+#pragma once
 
 #include <stdint.h>
 
 void clkin_detect_init(void);
 uint32_t clkin_frequency(void);
-
-#endif //__CLKIN_H__

--- a/firmware/common/cpld_jtag.h
+++ b/firmware/common/cpld_jtag.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __CPLD_JTAG_H__
-#define __CPLD_JTAG_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -59,5 +58,3 @@ int cpld_jtag_program(
 	unsigned char* const buffer,
 	refill_buffer_cb refill);
 unsigned char cpld_jtag_get_next_byte(void);
-
-#endif //__CPLD_JTAG_H__

--- a/firmware/common/cpld_xc2c.h
+++ b/firmware/common/cpld_xc2c.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __CPLD_XC2C_H__
-#define __CPLD_XC2C_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -69,5 +68,3 @@ bool cpld_xc2c64a_jtag_sram_verify(
 extern const cpld_xc2c64a_program_t cpld_hackrf_program_sram;
 extern const cpld_xc2c64a_verify_t cpld_hackrf_verify;
 extern const cpld_xc2c64a_row_addresses_t cpld_hackrf_row_addresses;
-
-#endif /*__CPLD_XC2C_H__*/

--- a/firmware/common/crc.h
+++ b/firmware/common/crc.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __CRC_H__
-#define __CRC_H__
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -35,5 +34,3 @@ typedef struct {
 void crc32_init(crc32_t* const crc);
 void crc32_update(crc32_t* const crc, const uint8_t* const data, const size_t byte_count);
 uint32_t crc32_digest(const crc32_t* const crc);
-
-#endif //__CRC_H__

--- a/firmware/common/da7219.h
+++ b/firmware/common/da7219.h
@@ -19,13 +19,10 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __DA7219_H
-#define __DA7219_H
+#pragma once
 
 #include <stdbool.h>
 
 #define DA7219_ADDRESS 0x1A
 
 bool da7219_detect(void);
-
-#endif /* __DA7219_H */

--- a/firmware/common/delay.h
+++ b/firmware/common/delay.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __DELAY_H
-#define __DELAY_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,4 +30,6 @@ extern "C" {
 void delay(uint32_t duration);
 void delay_us_at_mhz(uint32_t us, uint32_t mhz);
 
-#endif /* __DELAY_H */
+#ifdef __cplusplus
+}
+#endif

--- a/firmware/common/fault_handler.h
+++ b/firmware/common/fault_handler.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __FAULT_HANDLER__
-#define __FAULT_HANDLER__
+#pragma once
 
 #include <stdint.h>
 
@@ -71,5 +70,3 @@ static armv7m_scb_t* const SCB = (armv7m_scb_t*) SCB_BASE;
 #define SCB_HFSR_DEBUGEVT (1 << 31)
 #define SCB_HFSR_FORCED   (1 << 30)
 #define SCB_HFSR_VECTTBL  (1 << 1)
-
-#endif //__FAULT_HANDLER__

--- a/firmware/common/firmware_info.h
+++ b/firmware/common/firmware_info.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef FIRMWARE_INFO_H
-#define FIRMWARE_INFO_H
+#pragma once
 
 #include <stdint.h>
 
@@ -33,5 +32,3 @@ struct firmware_info_t {
 } __attribute__((packed, aligned(1)));
 
 extern const struct firmware_info_t firmware_info;
-
-#endif

--- a/firmware/common/fixed_point.h
+++ b/firmware/common/fixed_point.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __FIXED_POINT_H__
-#define __FIXED_POINT_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -32,5 +31,3 @@ typedef uint64_t fp_40_24_t;
 
 /* one in 40.24 fixed-point */
 #define FP_ONE_HZ (1 << 24)
-
-#endif /*__FIXED_POINT_H__*/

--- a/firmware/common/fpga.h
+++ b/firmware/common/fpga.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __FPGA_H
-#define __FPGA_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -94,5 +93,3 @@ bool fpga_image_load(struct fpga_loader_t* loader, unsigned int index);
 bool fpga_spi_selftest(void);
 bool fpga_sgpio_selftest(void);
 bool fpga_if_xcvr_selftest(void);
-
-#endif // __FPGA_H

--- a/firmware/common/fpga_regs.def
+++ b/firmware/common/fpga_regs.def
@@ -1,7 +1,7 @@
 /* -*- mode: c -*-
  *
  * Copyright 2012 Michael Ossmann
- * Copyright 2025 Great Scott Gadgets <info@greatscottgadgets.com>
+ * Copyright 2025-2026 Great Scott Gadgets <info@greatscottgadgets.com>
  *
  * This file is part of HackRF.
  *
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __FPGA_REGS_DEF
-#define __FPGA_REGS_DEF
+#pragma once
 
 #define FPGA_REG_SET_CLEAN(_d, _r) (_d->regs_dirty &= ~(1UL<<_r))
 #define FPGA_REG_SET_DIRTY(_d, _r) (_d->regs_dirty |= (1UL<<_r))
@@ -71,5 +70,3 @@ __MREG__(FPGA_STANDARD_TX_INTRP, 5, 0, 3)
 
 /* REG 06 (6): TX_PSTEP */
 __MREG__(FPGA_STANDARD_TX_PSTEP, 6, 0, 8)
-
-#endif // __FPGA_REGS_DEF

--- a/firmware/common/gpdma.h
+++ b/firmware/common/gpdma.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __GPDMA_H__
-#define __GPDMA_H__
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -40,5 +39,3 @@ void gpdma_lli_enable_interrupt(gpdma_lli_t* const lli);
 
 void gpdma_lli_create_loop(gpdma_lli_t* const lli, const size_t lli_count);
 void gpdma_lli_create_oneshot(gpdma_lli_t* const lli, const size_t lli_count);
-
-#endif /*__GPDMA_H__*/

--- a/firmware/common/gpio.h
+++ b/firmware/common/gpio.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __GPIO_H__
-#define __GPIO_H__
+#pragma once
 
 #include <stdbool.h>
 
@@ -35,5 +34,3 @@ void gpio_output(gpio_t gpio);
 void gpio_input(gpio_t gpio);
 void gpio_write(gpio_t gpio, const bool value);
 bool gpio_read(gpio_t gpio);
-
-#endif /*__GPIO_H__*/

--- a/firmware/common/gpio_lpc.h
+++ b/firmware/common/gpio_lpc.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __GPIO_LPC_H__
-#define __GPIO_LPC_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -69,5 +68,3 @@ struct gpio {
 	.gpio_w = GPIO_LPC_W(_port_num, _pin_num), \
 }
 // clang-format on
-
-#endif /*__GPIO_LPC_H__*/

--- a/firmware/common/hackrf_core.h
+++ b/firmware/common/hackrf_core.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __HACKRF_CORE_H
-#define __HACKRF_CORE_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -146,5 +145,3 @@ void pps_out_set(const uint8_t value);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __HACKRF_CORE_H */

--- a/firmware/common/hackrf_ui.h
+++ b/firmware/common/hackrf_ui.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef HACKRF_UI_H
-#define HACKRF_UI_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -71,5 +70,3 @@ typedef struct {
  */
 const hackrf_ui_t* hackrf_ui(void);
 void hackrf_ui_set_enable(bool);
-
-#endif

--- a/firmware/common/i2c_bus.h
+++ b/firmware/common/i2c_bus.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __I2C_BUS_H__
-#define __I2C_BUS_H__
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -51,5 +50,3 @@ void i2c_bus_transfer(
 	const size_t tx_count,
 	uint8_t* const rx,
 	const size_t rx_count);
-
-#endif /*__I2C_BUS_H__*/

--- a/firmware/common/i2c_lpc.h
+++ b/firmware/common/i2c_lpc.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __I2C_LPC_H__
-#define __I2C_LPC_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -43,5 +42,3 @@ void i2c_lpc_transfer(
 	uint8_t* const data_rx,
 	const size_t count_rx);
 bool i2c_probe(i2c_bus_t* const bus, const uint_fast8_t device_address);
-
-#endif /*__I2C_LPC_H__*/

--- a/firmware/common/ice40_spi.h
+++ b/firmware/common/ice40_spi.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __ICE40_SPI_H
-#define __ICE40_SPI_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -47,5 +46,3 @@ bool ice40_spi_syscfg_program(
 	uint8_t* buf,
 	size_t (*read_block_cb)(void* ctx),
 	void* read_ctx);
-
-#endif // __ICE40_SPI_H

--- a/firmware/common/locking.h
+++ b/firmware/common/locking.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __LOCKING_H__
-#define __LOCKING_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -51,5 +50,3 @@ static inline uint32_t store_exclusive(uint32_t val, volatile uint32_t* addr)
 	return 0;
 }
 #endif
-
-#endif /* __LOCKING_H__ */

--- a/firmware/common/lz4_blk.h
+++ b/firmware/common/lz4_blk.h
@@ -19,12 +19,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __LZ4_BLK_H
-#define __LZ4_BLK_H
+#pragma once
 
 #include <stdint.h>
 #include <stdlib.h>
 
 int lz4_blk_decompress(const uint8_t* src, uint8_t* dst, size_t length);
-
-#endif

--- a/firmware/common/lz4_buf.h
+++ b/firmware/common/lz4_buf.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __LZ4_BUF_H
-#define __LZ4_BUF_H
+#pragma once
 
 #include <stdint.h>
 
@@ -31,5 +30,3 @@
 
 extern uint8_t lz4_in_buf[LZ4_BUFFER_SIZE];
 extern uint8_t lz4_out_buf[LZ4_BUFFER_SIZE];
-
-#endif /*__LZ4_BUF_H */

--- a/firmware/common/m0_state.h
+++ b/firmware/common/m0_state.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __M0_STATE_H__
-#define __M0_STATE_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -60,5 +59,3 @@ enum m0_error {
 extern volatile struct m0_state m0_state;
 
 void m0_set_mode(enum m0_mode mode);
-
-#endif /*__M0_STATE_H__*/

--- a/firmware/common/max2831.h
+++ b/firmware/common/max2831.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2831_H
-#define __MAX2831_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -108,5 +107,3 @@ extern void max2831_tx(max2831_driver_t* const drv);
 extern void max2831_rx(max2831_driver_t* const drv);
 extern void max2831_tx_calibration(max2831_driver_t* const drv);
 extern void max2831_rx_calibration(max2831_driver_t* const drv);
-
-#endif // __MAX2831_H

--- a/firmware/common/max2831_regs.def
+++ b/firmware/common/max2831_regs.def
@@ -1,7 +1,27 @@
-/* -*- mode: c -*- */
+/* -*- mode: c -*-
+ *
+ * Copyright 2012 Michael Ossmann
+ * Copyright 2025-2026 Great Scott Gadgets <info@greatscottgadgets.com>
+ *
+ * This file is part of HackRF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
-#ifndef __MAX2831_REGS_DEF
-#define __MAX2831_REGS_DEF
+#pragma once
 
 /* Generate static inline accessors that operate on the global
  * regs. Done this way to (1) allow defs to be scraped out and used
@@ -128,5 +148,3 @@ __MREG__(MAX2831_RXIQ_VCM,15,10,2)  // RX I/Q output common mode
 #define MAX2831_RXIQ_VCM_1_2  1  // 1.2V
 #define MAX2831_RXIQ_VCM_1_3  2  // 1.3V
 #define MAX2831_RXIQ_VCM_1_45 3  // 1.45V
-
-#endif // __MAX2831_REGS_DEF

--- a/firmware/common/max2831_target.h
+++ b/firmware/common/max2831_target.h
@@ -19,12 +19,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2831_TARGET_H
-#define __MAX2831_TARGET_H
+#pragma once
 
 #include "max2831.h"
 
 void max2831_target_init(max2831_driver_t* const drv);
 void max2831_target_set_mode(max2831_driver_t* const drv, const max2831_mode_t new_mode);
-
-#endif // __MAX2831_TARGET_H

--- a/firmware/common/max2837.h
+++ b/firmware/common/max2837.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2837_H
-#define __MAX2837_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -91,5 +90,3 @@ bool max2837_set_txvga_gain(max2837_driver_t* const drv, const uint32_t gain_db)
 
 extern void max2837_tx(max2837_driver_t* const drv);
 extern void max2837_rx(max2837_driver_t* const drv);
-
-#endif // __MAX2837_H

--- a/firmware/common/max2837_regs.def
+++ b/firmware/common/max2837_regs.def
@@ -1,7 +1,26 @@
-/* -*- mode: c -*- */
+/* -*- mode: c -*-  *
+ * Copyright 2012 Michael Ossmann
+ * Copyright 2025-2026 Great Scott Gadgets <info@greatscottgadgets.com>
+ *
+ * This file is part of HackRF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
-#ifndef __MAX2837_REGS_DEF
-#define __MAX2837_REGS_DEF
+#pragma once
 
 /* Generate static inline accessors that operate on the global
  * regs. Done this way to (1) allow defs to be scraped out and used
@@ -404,5 +423,3 @@ __MREG__(MAX2837_FUSE_RTH,30,9,1)
 // 0 -> 992/0uA correction, 15 -> 0/992uA correction ... if TX_DCCORR_SPI_EN
 __MREG__(MAX2837_TX_DCCORR_I,31,4,5)
 __MREG__(MAX2837_TX_DCCORR_Q,31,9,5)
-
-#endif // __MAX2837_REGS_DEF

--- a/firmware/common/max2837_target.h
+++ b/firmware/common/max2837_target.h
@@ -21,12 +21,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2837_TARGET_H
-#define __MAX2837_TARGET_H
+#pragma once
 
 #include "max2837.h"
 
 void max2837_target_init(max2837_driver_t* const drv);
 void max2837_target_set_mode(max2837_driver_t* const drv, const max2837_mode_t new_mode);
-
-#endif // __MAX2837_TARGET_H

--- a/firmware/common/max2839.h
+++ b/firmware/common/max2839.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2839_H
-#define __MAX2839_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -93,5 +92,3 @@ bool max2839_set_txvga_gain(max2839_driver_t* const drv, const uint32_t gain_db)
 
 extern void max2839_tx(max2839_driver_t* const drv);
 extern void max2839_rx(max2839_driver_t* const drv);
-
-#endif // __MAX2839_H

--- a/firmware/common/max2839_regs.def
+++ b/firmware/common/max2839_regs.def
@@ -1,7 +1,26 @@
-/* -*- mode: c -*- */
+/* -*- mode: c -*-  *
+ * Copyright 2012 Michael Ossmann
+ * Copyright 2025-2026 Great Scott Gadgets <info@greatscottgadgets.com>
+ *
+ * This file is part of HackRF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
-#ifndef __MAX2839_REGS_DEF
-#define __MAX2839_REGS_DEF
+#pragma once
 
 /* Generate static inline accessors that operate on the global
  * regs. Done this way to (1) allow defs to be scraped out and used
@@ -255,5 +274,3 @@ __MREG__(MAX2839_PA_DAC_Voltage_Mode_Output_Select,30,9,1)
 __MREG__(MAX2839_TX_DC_Offset_Correction_QChannel,31,5,6)
 __MREG__(MAX2839_RESERVED_31_8,31,8,3)
 __MREG__(MAX2839_PA_DAC_Clk_Divide_Ratio,31,9,1)
-
-#endif // __MAX2839_REGS_DEF

--- a/firmware/common/max2839_target.h
+++ b/firmware/common/max2839_target.h
@@ -21,12 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX2839_TARGET_H
-#define __MAX2839_TARGET_H
-
 #include "max2839.h"
 
 void max2839_target_init(max2839_driver_t* const drv);
 void max2839_target_set_mode(max2839_driver_t* const drv, const max2839_mode_t new_mode);
-
-#endif // __MAX2839_TARGET_H

--- a/firmware/common/max283x.h
+++ b/firmware/common/max283x.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX283x_H
-#define __MAX283x_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -126,5 +125,3 @@ void max283x_set_rx_hpf_frequency(
 /* Perform MAX2831 TX and RX calibration. */
 void max283x_tx_calibration(max283x_driver_t* const drv);
 void max283x_rx_calibration(max283x_driver_t* const drv);
-
-#endif // __MAX283x_H

--- a/firmware/common/max2871.h
+++ b/firmware/common/max2871.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef MAX2871_H
-#define MAX2871_H
+#pragma once
 
 #include <stdint.h>
 
@@ -39,4 +38,3 @@ extern void max2871_setup(max2871_driver_t* const drv);
 extern uint64_t max2871_set_frequency(max2871_driver_t* const drv, uint16_t mhz);
 extern void max2871_enable(max2871_driver_t* const drv);
 extern void max2871_disable(max2871_driver_t* const drv);
-#endif

--- a/firmware/common/max2871_regs.h
+++ b/firmware/common/max2871_regs.h
@@ -19,8 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef MAX2871_REGS_H
-#define MAX2871_REGS_H
+#pragma once
+
 #include <stdint.h>
 
 #define MAX2871_VASA      (1 << 9)
@@ -75,4 +75,3 @@ void max2871_set_F01(uint32_t v);
 void max2871_set_LD(uint32_t v);
 void max2871_set_ADCS(uint32_t v);
 void max2871_set_ADCM(uint32_t v);
-#endif

--- a/firmware/common/max5864.h
+++ b/firmware/common/max5864.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX5864_H
-#define __MAX5864_H
+#pragma once
 
 #include "spi_bus.h"
 
@@ -41,5 +40,3 @@ void max5864_idle(max5864_driver_t* const drv);
 void max5864_rx(max5864_driver_t* const drv);
 void max5864_tx(max5864_driver_t* const drv);
 void max5864_xcvr(max5864_driver_t* const drv);
-
-#endif // __MAX5864_H

--- a/firmware/common/max5864_target.h
+++ b/firmware/common/max5864_target.h
@@ -20,11 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MAX5864_TARGET_H__
-#define __MAX5864_TARGET_H__
+#pragma once
 
 #include "max5864.h"
 
 void max5864_target_init(max5864_driver_t* const drv);
-
-#endif /*__MAX5864_TARGET_H__*/

--- a/firmware/common/mixer.h
+++ b/firmware/common/mixer.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __MIXER_H
-#define __MIXER_H
+#pragma once
 
 #if defined(JAWBREAKER) || defined(HACKRF_ONE) || defined(PRALINE)
 	#include "rffc5071.h"
@@ -41,5 +40,3 @@ extern uint64_t mixer_set_frequency(mixer_driver_t* const mixer, uint64_t hz);
 extern void mixer_enable(mixer_driver_t* const mixer);
 extern void mixer_disable(mixer_driver_t* const mixer);
 extern void mixer_set_gpo(mixer_driver_t* const drv, uint8_t gpo);
-
-#endif // __MIXER_H

--- a/firmware/common/operacake.h
+++ b/firmware/common/operacake.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __OPERACAKE_H
-#define __OPERACAKE_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,5 +56,3 @@ uint16_t gpio_test(uint8_t address);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __OPERACAKE_H */

--- a/firmware/common/operacake_sctimer.h
+++ b/firmware/common/operacake_sctimer.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __OPERACAKE_SCTIMER_H
-#define __OPERACAKE_SCTIMER_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -37,5 +36,3 @@ void operacake_sctimer_enable(bool enable);
 void operacake_sctimer_set_dwell_times(struct operacake_dwell_times* times, int n);
 void operacake_sctimer_stop(void);
 void operacake_sctimer_reset_state(void);
-
-#endif /* __OPERACAKE_SCTIMER_H */

--- a/firmware/common/platform_detect.h
+++ b/firmware/common/platform_detect.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __PLATFORM_DETECT_H__
-#define __PLATFORM_DETECT_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -76,5 +75,3 @@ void detect_hardware_platform(void);
 board_id_t detected_platform(void);
 board_rev_t detected_revision(void);
 uint32_t supported_platform(void);
-
-#endif //__PLATFORM_DETECT_H__

--- a/firmware/common/platform_gpio.h
+++ b/firmware/common/platform_gpio.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __PLATFORM_GPIO_H
-#define __PLATFORM_GPIO_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -369,5 +368,3 @@ static const struct gpio GPIO7_25 = GPIO(7, 25);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __PLATFORM_GPIO_H */

--- a/firmware/common/platform_scu.h
+++ b/firmware/common/platform_scu.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __PLATFORM_SCU_H
-#define __PLATFORM_SCU_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -307,5 +306,3 @@ const platform_scu_t* platform_scu(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __PLATFORM_SCU_H */

--- a/firmware/common/portapack.h
+++ b/firmware/common/portapack.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __PORTAPACK_H__
-#define __PORTAPACK_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -85,5 +84,3 @@ void portapack_draw_bitmap(
 	const ui_color_t background);
 
 ui_bitmap_t portapack_font_glyph(const ui_font_t* const font, const char c);
-
-#endif /*__PORTAPACK_H__*/

--- a/firmware/common/rad1o/decoder.h
+++ b/firmware/common/rad1o/decoder.h
@@ -1,8 +1,5 @@
-#ifndef __RAD1O_DECODER_H__
-#define __RAD1O_DECODER_H__
+#pragma once
 
 #include <stdint.h>
 
 uint8_t* rad1o_pk_decode(const uint8_t* data, int* len);
-
-#endif

--- a/firmware/common/rad1o/display.h
+++ b/firmware/common/rad1o/display.h
@@ -1,5 +1,4 @@
-#ifndef __RAD1O_DISPLAY_H__
-#define __RAD1O_DISPLAY_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -27,5 +26,3 @@ void rad1o_lcdFill(uint8_t f);
 void rad1o_lcdDisplay(void);
 void rad1o_lcdSetPixel(uint8_t x, uint8_t y, uint8_t f);
 uint8_t* rad1o_lcdGetBuffer(void);
-
-#endif

--- a/firmware/common/rad1o/draw.h
+++ b/firmware/common/rad1o/draw.h
@@ -1,9 +1,6 @@
-#ifndef __RAD1O_DRAW_H__
-#define __RAD1O_DRAW_H__
+#pragma once
 
 #include <stdint.h>
 
 void rad1o_drawHLine(uint8_t y, uint8_t x1, uint8_t x2, uint8_t color);
 void rad1o_drawVLine(uint8_t x, uint8_t y1, uint8_t y2, uint8_t color);
-
-#endif

--- a/firmware/common/rad1o/fonts.h
+++ b/firmware/common/rad1o/fonts.h
@@ -1,5 +1,4 @@
-#ifndef __RAD1O_FONTS_H__
-#define __RAD1O_FONTS_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -31,5 +30,3 @@ typedef const struct FONT_DEF* FONT;
 #define FONT_DEFAULT  0
 #define FONT_INTERNAL 1
 #define FONT_EXTERNAL 2
-
-#endif

--- a/firmware/common/rad1o/print.h
+++ b/firmware/common/rad1o/print.h
@@ -1,5 +1,4 @@
-#ifndef __RAD1O_PRINT_H__
-#define __RAD1O_PRINT_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -9,5 +8,3 @@ void rad1o_lcdClear(void);
 void rad1o_lcdMoveCrsr(int32_t dx, int32_t dy);
 void rad1o_lcdSetCrsr(int32_t dx, int32_t dy);
 void rad1o_setSystemFont(void);
-
-#endif

--- a/firmware/common/rad1o/render.h
+++ b/firmware/common/rad1o/render.h
@@ -1,5 +1,4 @@
-#ifndef __RENDER_H_
-#define __RENDER_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -10,4 +9,4 @@ void rad1o_setIntFont(const struct FONT_DEF* font);
 int rad1o_getFontHeight(void);
 int rad1o_DoString(int sx, int sy, const char* s);
 int rad1o_DoChar(int sx, int sy, int c);
-#endif
+

--- a/firmware/common/rad1o/render.h
+++ b/firmware/common/rad1o/render.h
@@ -9,4 +9,3 @@ void rad1o_setIntFont(const struct FONT_DEF* font);
 int rad1o_getFontHeight(void);
 int rad1o_DoString(int sx, int sy, const char* s);
 int rad1o_DoChar(int sx, int sy, int c);
-

--- a/firmware/common/rad1o/smallfonts.h
+++ b/firmware/common/rad1o/smallfonts.h
@@ -35,12 +35,10 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**************************************************************************/
-#ifndef __RAD1O_SMALLFONTS_H__
-#define __RAD1O_SMALLFONTS_H__
+
+#pragma once
 
 /* Partially based on original code for the KS0108 by Stephane Rey */
 /* Current version by Kevin Townsend */
 
 extern const struct FONT_DEF Font_7x8;
-
-#endif

--- a/firmware/common/rad1o/ubuntu18.h
+++ b/firmware/common/rad1o/ubuntu18.h
@@ -1,6 +1,3 @@
-#ifndef __RAD1O_UBUNTU18_H__
-#define __RAD1O_UBUNTU18_H__
+#pragma once
 
 extern const struct FONT_DEF Font_Ubuntu18pt;
-
-#endif

--- a/firmware/common/radio.h
+++ b/firmware/common/radio.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __RF_CONFIG_H__
-#define __RF_CONFIG_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -254,5 +253,3 @@ bool radio_update(radio_t* const radio);
  * the request bank for the new mode.
  */
 void radio_switch_opmode(radio_t* const radio, const transceiver_mode_t mode);
-
-#endif /*__RF_CONFIG_H__*/

--- a/firmware/common/rf_path.h
+++ b/firmware/common/rf_path.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __RFPATH_H__
-#define __RFPATH_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -96,5 +95,3 @@ void rf_path_set_filter(rf_path_t* const rf_path, const rf_path_filter_t filter)
 
 void rf_path_set_lna(rf_path_t* const rf_path, const uint_fast8_t enable);
 void rf_path_set_antenna(rf_path_t* const rf_path, const uint_fast8_t enable);
-
-#endif /*__RFPATH_H__*/

--- a/firmware/common/rffc5071.h
+++ b/firmware/common/rffc5071.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __RFFC5071_H
-#define __RFFC5071_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -71,5 +70,3 @@ extern void rffc5071_set_gpo(rffc5071_driver_t* const drv, uint8_t);
 extern bool rffc5071_poll_ld(rffc5071_driver_t* const drv, uint8_t* prelock_state);
 #endif
 extern bool rffc5071_check_lock(rffc5071_driver_t* const drv);
-
-#endif // __RFFC5071_H

--- a/firmware/common/rffc5071_regs.def
+++ b/firmware/common/rffc5071_regs.def
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __RFFC5071_REGS_DEF
-#define __RFFC5071_REGS_DEF
+#pragma once
 
 #define RFFC5071_REG_SET_CLEAN(_d, _r) (_d->regs_dirty &= ~(1UL<<_r))
 #define RFFC5071_REG_SET_DIRTY(_d, _r) (_d->regs_dirty |= (1UL<<_r))
@@ -257,5 +256,3 @@ __MREG__(RFFC5071_LFSR,30,9,1)
 __MREG__(RFFC5071_TSEL,30,10,2)
 __MREG__(RFFC5071_TMUX,30,12,3)
 __MREG__(RFFC5071_TEN,30,15,1)
-
-#endif // __RFFC5071_REGS_DEF

--- a/firmware/common/rffc5071_spi.h
+++ b/firmware/common/rffc5071_spi.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __RFFC5071_SPI_H
-#define __RFFC5071_SPI_H
+#pragma once
 
 #include <stddef.h>
 
@@ -41,5 +40,3 @@ void rffc5071_spi_transfer_gather(
 	spi_bus_t* const bus,
 	const spi_transfer_t* const transfer,
 	const size_t count);
-
-#endif // __RFFC5071_SPI_H

--- a/firmware/common/rom_iap.h
+++ b/firmware/common/rom_iap.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __ROM_IAP__
-#define __ROM_IAP__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -93,7 +92,7 @@ typedef enum
 	INVALID_FLASH_UNIT             = 0x00000014, /* Invalid flash unit. */
 	USER_CODE_CHECKSUM             = 0x00000015,
 	ERROR_SETTING_ACTIVE_PARTITION = 0x00000016,
-	
+
 	/* Special Error */
 	ERROR_IAP_NOT_IMPLEMENTED      = 0x00000100 /* IAP is not implemented in this part */
 } isp_iap_ret_code_t;
@@ -118,5 +117,3 @@ typedef struct {
 bool iap_is_implemented(void);
 
 isp_iap_ret_code_t iap_cmd_call(iap_cmd_res_t* iap_cmd_res);
-
-#endif //__ROM_IAP__

--- a/firmware/common/sct.h
+++ b/firmware/common/sct.h
@@ -19,6 +19,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#pragma once
+
 #include <libopencm3/cm3/common.h>
 #include <libopencm3/lpc43xx/memorymap.h>
 

--- a/firmware/common/selftest.h
+++ b/firmware/common/selftest.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __SELFTEST_H
-#define __SELFTEST_H
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -76,5 +75,3 @@ typedef struct {
 } selftest_t;
 
 extern selftest_t selftest;
-
-#endif // __SELFTEST_H

--- a/firmware/common/sgpio.h
+++ b/firmware/common/sgpio.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __SGPIO_H__
-#define __SGPIO_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -50,5 +49,3 @@ void sgpio_cpld_stream_disable(sgpio_config_t* const config);
 bool sgpio_cpld_stream_is_enabled(sgpio_config_t* const config);
 
 void sgpio_cpld_set_mixer_invert(sgpio_config_t* const config, uint_fast8_t invert);
-
-#endif //__SGPIO_H__

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __SI5351C_H
-#define __SI5351C_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,5 +114,3 @@ void si5351c_set_phase(
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __SI5351C_H */

--- a/firmware/common/spi_bus.h
+++ b/firmware/common/spi_bus.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __SPI_BUS_H__
-#define __SPI_BUS_H__
+#pragma once
 
 #include <stddef.h>
 
@@ -52,5 +51,3 @@ void spi_bus_transfer_gather(
 	spi_bus_t* const bus,
 	const spi_transfer_t* const transfers,
 	const size_t count);
-
-#endif /*__SPI_BUS_H__*/

--- a/firmware/common/spi_ssp.h
+++ b/firmware/common/spi_ssp.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __SPI_SSP_H__
-#define __SPI_SSP_H__
+#pragma once
 
 #include <stdint.h>
 #include <stddef.h>
@@ -46,5 +45,3 @@ void spi_ssp_transfer_gather(
 	spi_bus_t* const bus,
 	const spi_transfer_t* const transfers,
 	const size_t count);
-
-#endif /*__SPI_SSP_H__*/

--- a/firmware/common/streaming.h
+++ b/firmware/common/streaming.h
@@ -21,12 +21,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __STREAMING_H__
-#define __STREAMING_H__
+#pragma once
 
 #include <sgpio.h>
 
 void baseband_streaming_enable(sgpio_config_t* const sgpio_config);
 void baseband_streaming_disable(sgpio_config_t* const sgpio_config);
-
-#endif /*__STREAMING_H__*/

--- a/firmware/common/tune_config.h
+++ b/firmware/common/tune_config.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __TUNE_CONFIG_H__
-#define __TUNE_CONFIG_H__
+#pragma once
 
 #ifdef PRALINE
 	#include "fpga.h"
@@ -391,5 +390,3 @@ static const tune_config_t praline_tune_config_rx[] = {
 };
 // clang-format on
 #endif
-
-#endif /*__TUNE_CONFIG_H__*/

--- a/firmware/common/tuning.h
+++ b/firmware/common/tuning.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __TUNING_H__
-#define __TUNING_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -46,5 +45,3 @@ bool tuning_set_frequency(
 	const uint64_t freq,
 	const uint32_t offset);
 #endif
-
-#endif /*__TUNING_H__*/

--- a/firmware/common/ui_portapack.h
+++ b/firmware/common/ui_portapack.h
@@ -20,11 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __UI_PORTAPACK_H__
-#define __UI_PORTAPACK_H__
+#pragma once
 
 #include "hackrf_ui.h"
 
 const hackrf_ui_t* portapack_hackrf_ui_init(void) __attribute__((weak));
-
-#endif /*__UI_PORTAPACK_H__*/

--- a/firmware/common/ui_rad1o.h
+++ b/firmware/common/ui_rad1o.h
@@ -20,11 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __UI_RAD1O_H__
-#define __UI_RAD1O_H__
+#pragma once
 
 #include "hackrf_ui.h"
 
 const hackrf_ui_t* rad1o_ui_setup(void) __attribute__((weak));
-
-#endif /*__UI_RAD1O_H__*/

--- a/firmware/common/usb.h
+++ b/firmware/common/usb.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_H__
-#define __USB_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -77,5 +76,3 @@ void usb_endpoint_schedule_append(
 	const usb_endpoint_t* const endpoint,
 	usb_transfer_descriptor_t* const tail_td,
 	usb_transfer_descriptor_t* const new_td);
-
-#endif //__USB_H__

--- a/firmware/common/usb_queue.h
+++ b/firmware/common/usb_queue.h
@@ -80,4 +80,3 @@ int usb_transfer_schedule_ack(const usb_endpoint_t* const endpoint);
 void usb_queue_init(usb_queue_t* const queue);
 
 void usb_queue_transfer_complete(usb_endpoint_t* const endpoint);
-

--- a/firmware/common/usb_queue.h
+++ b/firmware/common/usb_queue.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_QUEUE_H__
-#define __USB_QUEUE_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -82,4 +81,3 @@ void usb_queue_init(usb_queue_t* const queue);
 
 void usb_queue_transfer_complete(usb_endpoint_t* const endpoint);
 
-#endif //__USB_QUEUE_H__

--- a/firmware/common/usb_request.h
+++ b/firmware/common/usb_request.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_REQUEST_H__
-#define __USB_REQUEST_H__
+#pragma once
 
 #include "usb_type.h"
 
@@ -61,5 +60,3 @@ void usb_setup_complete(usb_endpoint_t* const endpoint);
 void usb_control_in_complete(usb_endpoint_t* const endpoint);
 
 void usb_control_out_complete(usb_endpoint_t* const endpoint);
-
-#endif //__USB_REQUEST_H__

--- a/firmware/common/usb_standard_request.h
+++ b/firmware/common/usb_standard_request.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_STANDARD_REQUEST_H__
-#define __USB_STANDARD_REQUEST_H__
+#pragma once
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -50,5 +49,3 @@ usb_transfer_type_t usb_endpoint_descriptor_transfer_type(
 bool usb_set_configuration(
 	usb_device_t* const device,
 	const uint_fast8_t configuration_number);
-
-#endif //__USB_STANDARD_REQUEST_H__

--- a/firmware/common/usb_type.h
+++ b/firmware/common/usb_type.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_TYPE_H__
-#define __USB_TYPE_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -157,5 +156,3 @@ struct usb_endpoint_t {
 	void (*setup_complete)(usb_endpoint_t* const endpoint);
 	void (*transfer_complete)(usb_endpoint_t* const endpoint);
 };
-
-#endif //__USB_TYPE_H__

--- a/firmware/common/w25q80bv.h
+++ b/firmware/common/w25q80bv.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __W25Q80BV_H__
-#define __W25Q80BV_H__
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -69,5 +68,3 @@ void w25q80bv_read(
 	uint32_t len,
 	uint8_t* const data);
 void w25q80bv_clear_status(w25q80bv_driver_t* const drv);
-
-#endif //__W25Q80BV_H__

--- a/firmware/common/w25q80bv_target.h
+++ b/firmware/common/w25q80bv_target.h
@@ -20,11 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __W25Q80BV_TARGET_H__
-#define __W25Q80BV_TARGET_H__
+#pragma once
 
 #include "w25q80bv.h"
 
 void w25q80bv_target_init(w25q80bv_driver_t* const drv);
-
-#endif /*__W25Q80BV_TARGET_H__*/

--- a/firmware/hackrf_usb/usb_api_adc.h
+++ b/firmware/hackrf_usb/usb_api_adc.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_ADC_H__
-#define __USB_API_ADC_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -28,5 +27,3 @@
 usb_request_status_t usb_vendor_request_adc_read(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif // __USB_API_ADC_H__

--- a/firmware/hackrf_usb/usb_api_board_info.h
+++ b/firmware/hackrf_usb/usb_api_board_info.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_BOARD_INFO_H__
-#define __USB_API_BOARD_INFO_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -52,5 +51,3 @@ usb_request_status_t usb_vendor_request_read_board_rev(
 usb_request_status_t usb_vendor_request_read_supported_platform(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_BOARD_INFO_H__ */

--- a/firmware/hackrf_usb/usb_api_cpld.h
+++ b/firmware/hackrf_usb/usb_api_cpld.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_CPLD_H__
-#define __USB_API_CPLD_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -32,5 +31,3 @@ void cpld_update(void);
 usb_request_status_t usb_vendor_request_cpld_checksum(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_CPLD_H__ */

--- a/firmware/hackrf_usb/usb_api_m0_state.h
+++ b/firmware/hackrf_usb/usb_api_m0_state.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __M0_STATE_USB_H__
-#define __M0_STATE_USB_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -28,5 +27,3 @@
 usb_request_status_t usb_vendor_request_get_m0_state(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /*__M0_STATE_USB_H__*/

--- a/firmware/hackrf_usb/usb_api_operacake.h
+++ b/firmware/hackrf_usb/usb_api_operacake.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_OPERACAKE_H__
-#define __USB_API_OPERACAKE_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -53,5 +52,3 @@ usb_request_status_t usb_vendor_request_operacake_get_mode(
 usb_request_status_t usb_vendor_request_operacake_set_dwell_times(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_OPERACAKE_H__ */

--- a/firmware/hackrf_usb/usb_api_praline.h
+++ b/firmware/hackrf_usb/usb_api_praline.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_PRALINE_H__
-#define __USB_API_PRALINE_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -44,5 +43,3 @@ usb_request_status_t usb_vendor_request_set_narrowband_filter(
 usb_request_status_t usb_vendor_request_set_fpga_bitstream(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_PRALINE_H__ */

--- a/firmware/hackrf_usb/usb_api_register.h
+++ b/firmware/hackrf_usb/usb_api_register.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_REGISTER_H__
-#define __USB_API_REGISTER_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -71,5 +70,3 @@ usb_request_status_t usb_vendor_request_write_radio_reg(
 usb_request_status_t usb_vendor_request_read_radio_reg(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_REGISTER_H__ */

--- a/firmware/hackrf_usb/usb_api_selftest.h
+++ b/firmware/hackrf_usb/usb_api_selftest.h
@@ -19,8 +19,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_SELFTEST_H
-#define __USB_API_SELFTEST_H
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -32,5 +31,3 @@ usb_request_status_t usb_vendor_request_read_selftest(
 usb_request_status_t usb_vendor_request_test_rtc_osc(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif // __USB_API_SELFTEST_H

--- a/firmware/hackrf_usb/usb_api_spiflash.h
+++ b/firmware/hackrf_usb/usb_api_spiflash.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_SPIFLASH_H__
-#define __USB_API_SPIFLASH_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -42,5 +41,3 @@ usb_request_status_t usb_vendor_request_spiflash_status(
 usb_request_status_t usb_vendor_request_spiflash_clear_status(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_SPIFLASH_H__ */

--- a/firmware/hackrf_usb/usb_api_sweep.h
+++ b/firmware/hackrf_usb/usb_api_sweep.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_SWEEP_H__
-#define __USB_API_SWEEP_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -38,5 +37,3 @@ usb_request_status_t usb_vendor_request_init_sweep(
 	const usb_transfer_stage_t stage);
 
 void sweep_mode(uint32_t seq);
-
-#endif /* __USB_API_SWEEP_H__ */

--- a/firmware/hackrf_usb/usb_api_transceiver.h
+++ b/firmware/hackrf_usb/usb_api_transceiver.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_TRANSCEIVER_H__
-#define __USB_API_TRANSCEIVER_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -83,5 +82,3 @@ void transceiver_shutdown(void);
 void rx_mode(uint32_t seq);
 void tx_mode(uint32_t seq);
 void off_mode(uint32_t seq);
-
-#endif /*__USB_API_TRANSCEIVER_H__*/

--- a/firmware/hackrf_usb/usb_api_ui.h
+++ b/firmware/hackrf_usb/usb_api_ui.h
@@ -20,8 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_API_UI_H__
-#define __USB_API_UI_H__
+#pragma once
 
 #include <usb_request.h>
 #include <usb_type.h>
@@ -29,5 +28,3 @@
 usb_request_status_t usb_vendor_request_set_ui_enable(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage);
-
-#endif /* end of include guard: __USB_API_UI_H__ */

--- a/firmware/hackrf_usb/usb_bulk_buffer.h
+++ b/firmware/hackrf_usb/usb_bulk_buffer.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_BULK_BUFFER_H__
-#define __USB_BULK_BUFFER_H__
+#pragma once
 
 #include <stdint.h>
 
@@ -34,5 +33,3 @@
  * unless you also adjust the ldscripts.
  */
 extern uint8_t usb_bulk_buffer[USB_BULK_BUFFER_SIZE];
-
-#endif /*__USB_BULK_BUFFER_H__*/

--- a/firmware/hackrf_usb/usb_descriptor.h
+++ b/firmware/hackrf_usb/usb_descriptor.h
@@ -20,6 +20,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#pragma once
+
 #include <stdint.h>
 
 extern uint8_t usb_descriptor_device[];

--- a/firmware/hackrf_usb/usb_device.h
+++ b/firmware/hackrf_usb/usb_device.h
@@ -21,11 +21,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_DEVICE_H__
-#define __USB_DEVICE_H__
+#pragma once
 
 #include <usb_type.h>
 
 extern usb_device_t usb_device;
-
-#endif /* end of include guard: __USB_DEVICE_H__ */

--- a/firmware/hackrf_usb/usb_endpoint.h
+++ b/firmware/hackrf_usb/usb_endpoint.h
@@ -21,8 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef __USB_ENDPOINT_H__
-#define __USB_ENDPOINT_H__
+#pragma once
 
 #include <usb_queue.h>
 #include <usb_type.h>
@@ -38,5 +37,3 @@ extern USB_DECLARE_QUEUE(usb_endpoint_bulk_in);
 
 extern usb_endpoint_t usb_endpoint_bulk_out;
 extern USB_DECLARE_QUEUE(usb_endpoint_bulk_out);
-
-#endif /* end of include guard: __USB_ENDPOINT_H__ */

--- a/host/libhackrf/src/hackrf.h
+++ b/host/libhackrf/src/hackrf.h
@@ -21,8 +21,7 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABI
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef __HACKRF_H__
-#define __HACKRF_H__
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -2389,5 +2388,3 @@ extern ADDAPI int ADDCALL hackrf_radio_write_register(
 #ifdef __cplusplus
 } // __cplusplus defined.
 #endif
-
-#endif /*__HACKRF_H__*/


### PR DESCRIPTION
Depends on #1701

---

This PR removes include guards in the style of:

```c
#ifndef __SOME_FILE_H__
#define __SOME_FILE_H__

...

#endif // __SOME_FILE_H__
```

…and replaces them with:

```c

#pragma once 

...
```