### PR TITLE
Standardize `struct` + `typedef` usage.

### DIFF
--- a/firmware/common/cpld_jtag.h
+++ b/firmware/common/cpld_jtag.h
@@ -25,7 +25,7 @@
 
 #include "gpio.h"
 
-typedef struct jtag_gpio_t {
+typedef struct {
 	gpio_t gpio_tck;
 #ifndef PRALINE
 	gpio_t gpio_tms;
@@ -38,7 +38,7 @@ typedef struct jtag_gpio_t {
 #endif
 } jtag_gpio_t;
 
-typedef struct jtag_t {
+typedef struct {
 	jtag_gpio_t* const gpio;
 } jtag_t;
 

--- a/firmware/common/fault_handler.h
+++ b/firmware/common/fault_handler.h
@@ -29,9 +29,7 @@
 // TODO: Move all this to a Cortex-M(?) include file, since these
 // structures are supposedly the same between processors (to an
 // undetermined extent).
-typedef struct armv7m_scb_t armv7m_scb_t;
-
-struct armv7m_scb_t {
+typedef struct {
 	volatile const uint32_t CPUID;
 	volatile uint32_t ICSR;
 	volatile uint32_t VTOR;
@@ -63,7 +61,7 @@ struct armv7m_scb_t {
 	volatile const uint32_t ID_ISAR4;
 	volatile const uint32_t __reserved_0x74_0x87[5];
 	volatile uint32_t CPACR;
-} __attribute__((packed));
+} __attribute__((packed)) armv7m_scb_t;
 
 static armv7m_scb_t* const SCB = (armv7m_scb_t*) SCB_BASE;
 

--- a/firmware/common/fpga.h
+++ b/firmware/common/fpga.h
@@ -36,14 +36,11 @@ typedef enum {
 	FPGA_QUARTER_SHIFT_MODE_DOWN = 0b01,
 } fpga_quarter_shift_mode_t;
 
-struct fpga_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct fpga_driver_t fpga_driver_t;
-
-struct fpga_driver_t {
+typedef struct {
 	ice40_spi_driver_t* bus;
 	uint8_t regs[FPGA_NUM_REGS];
 	uint8_t regs_dirty;
-};
+} fpga_driver_t;
 
 struct fpga_loader_t {
 	/* Start address added as an offset to all read() calls. */

--- a/firmware/common/gpio_lpc.h
+++ b/firmware/common/gpio_lpc.h
@@ -29,7 +29,7 @@
  * register #defines and API declarations into separate header files.
  */
 
-typedef struct gpio_port {
+typedef struct {
 	volatile uint32_t dir; /* +0x000 */
 	uint32_t _reserved0[31];
 	volatile uint32_t mask; /* +0x080 */

--- a/firmware/common/i2c_bus.h
+++ b/firmware/common/i2c_bus.h
@@ -25,21 +25,18 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct i2c_bus_t; // IWYU pragma: keep - fixed in #1704
-typedef struct i2c_bus_t i2c_bus_t;
-
-struct i2c_bus_t {
+typedef struct _i2c_bus_t {
 	void* const obj;
-	void (*start)(i2c_bus_t* const bus, const void* const config);
-	void (*stop)(i2c_bus_t* const bus);
+	void (*start)(struct _i2c_bus_t* const bus, const void* const config);
+	void (*stop)(struct _i2c_bus_t* const bus);
 	void (*transfer)(
-		i2c_bus_t* const bus,
+		struct _i2c_bus_t* const bus,
 		const uint_fast8_t peripheral_address,
 		const uint8_t* const tx,
 		const size_t tx_count,
 		uint8_t* const rx,
 		const size_t rx_count);
-};
+} i2c_bus_t;
 
 void i2c_bus_start(i2c_bus_t* const bus, const void* const config);
 void i2c_bus_stop(i2c_bus_t* const bus);

--- a/firmware/common/i2c_lpc.h
+++ b/firmware/common/i2c_lpc.h
@@ -28,7 +28,7 @@
 
 #include "i2c_bus.h"
 
-typedef struct i2c_lpc_config_t {
+typedef struct {
 	const uint16_t duty_cycle_count;
 } i2c_lpc_config_t;
 

--- a/firmware/common/ice40_spi.h
+++ b/firmware/common/ice40_spi.h
@@ -28,15 +28,12 @@
 #include "gpio.h"
 #include "spi_bus.h"
 
-struct ice40_spi_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct ice40_spi_driver_t ice40_spi_driver_t;
-
-struct ice40_spi_driver_t {
+typedef struct {
 	spi_bus_t* const bus;
 	gpio_t gpio_select;
 	gpio_t gpio_creset;
 	gpio_t gpio_cdone;
-};
+} ice40_spi_driver_t;
 
 void ice40_spi_target_init(ice40_spi_driver_t* const drv);
 uint8_t ice40_spi_read(ice40_spi_driver_t* const drv, uint8_t r);

--- a/firmware/common/max2831.h
+++ b/firmware/common/max2831.h
@@ -47,22 +47,21 @@ typedef enum {
 	MAX2831_RX_HPF_600_KHZ = 3,
 } max2831_rx_hpf_freq_t;
 
-struct max2831_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct max2831_driver_t max2831_driver_t;
-
-struct max2831_driver_t {
+typedef struct _max2831_driver_t {
 	spi_bus_t* bus;
 	gpio_t gpio_enable;
 	gpio_t gpio_rxtx;
 	gpio_t gpio_rxhp;
 	gpio_t gpio_ld;
-	void (*target_init)(max2831_driver_t* const drv);
-	void (*set_mode)(max2831_driver_t* const drv, const max2831_mode_t new_mode);
+	void (*target_init)(struct _max2831_driver_t* const drv);
+	void (*set_mode)(
+		struct _max2831_driver_t* const drv,
+		const max2831_mode_t new_mode);
 	max2831_mode_t mode;
 	uint16_t regs[MAX2831_NUM_REGS];
 	uint16_t regs_dirty;
 	uint32_t desired_lpf_bw;
-};
+} max2831_driver_t;
 
 /* Initialize chip. */
 extern void max2831_setup(max2831_driver_t* const drv);

--- a/firmware/common/max2837.h
+++ b/firmware/common/max2837.h
@@ -40,20 +40,19 @@ typedef enum {
 	MAX2837_MODE_RX
 } max2837_mode_t;
 
-struct max2837_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct max2837_driver_t max2837_driver_t;
-
-struct max2837_driver_t {
+typedef struct _max2837_driver_t {
 	spi_bus_t* bus;
 	gpio_t gpio_enable;
 	gpio_t gpio_rx_enable;
 	gpio_t gpio_tx_enable;
-	void (*target_init)(max2837_driver_t* const drv);
-	void (*set_mode)(max2837_driver_t* const drv, const max2837_mode_t new_mode);
+	void (*target_init)(struct _max2837_driver_t* const drv);
+	void (*set_mode)(
+		struct _max2837_driver_t* const drv,
+		const max2837_mode_t new_mode);
 	max2837_mode_t mode;
 	uint16_t regs[MAX2837_NUM_REGS];
 	uint32_t regs_dirty;
-};
+} max2837_driver_t;
 
 /* Initialize chip. */
 extern void max2837_setup(max2837_driver_t* const drv);

--- a/firmware/common/max2839.h
+++ b/firmware/common/max2839.h
@@ -43,19 +43,18 @@ typedef enum {
 	MAX2839_MODE_CLKOUT,
 } max2839_mode_t;
 
-struct max2839_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct max2839_driver_t max2839_driver_t;
-
-struct max2839_driver_t {
+typedef struct _max2839_driver_t {
 	spi_bus_t* bus;
 	gpio_t gpio_enable;
 	gpio_t gpio_rxtx;
-	void (*target_init)(max2839_driver_t* const drv);
-	void (*set_mode)(max2839_driver_t* const drv, const max2839_mode_t new_mode);
+	void (*target_init)(struct _max2839_driver_t* const drv);
+	void (*set_mode)(
+		struct _max2839_driver_t* const drv,
+		const max2839_mode_t new_mode);
 	max2839_mode_t mode;
 	uint16_t regs[MAX2839_NUM_REGS];
 	uint32_t regs_dirty;
-};
+} max2839_driver_t;
 
 /* Initialize chip. */
 extern void max2839_setup(max2839_driver_t* const drv);

--- a/firmware/common/max5864.h
+++ b/firmware/common/max5864.h
@@ -24,13 +24,10 @@
 
 #include "spi_bus.h"
 
-struct max5864_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct max5864_driver_t max5864_driver_t;
-
-struct max5864_driver_t {
+typedef struct _max5864_driver_t {
 	spi_bus_t* const bus;
-	void (*target_init)(max5864_driver_t* const drv);
-};
+	void (*target_init)(struct _max5864_driver_t* const drv);
+} max5864_driver_t;
 
 void max5864_setup(max5864_driver_t* const drv);
 

--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -38,7 +38,7 @@ static void portapack_sleep_milliseconds(const uint32_t milliseconds)
 	delay(milliseconds * 40800);
 }
 
-typedef struct portapack_if_t {
+typedef struct {
 	gpio_t gpio_dir;
 	gpio_t gpio_lcd_rdx;
 	gpio_t gpio_lcd_wrx;

--- a/firmware/common/portapack.h
+++ b/firmware/common/portapack.h
@@ -28,31 +28,31 @@
 
 #define ARRAY_SIZEOF(x) (sizeof(x) / sizeof(x[0]))
 
-typedef struct ui_color_t {
+typedef struct {
 	uint16_t v;
 } ui_color_t;
 
-typedef struct ui_point_t {
+typedef struct {
 	int16_t x;
 	int16_t y;
 } ui_point_t;
 
-typedef struct ui_size_t {
+typedef struct {
 	int16_t width;
 	int16_t height;
 } ui_size_t;
 
-typedef struct ui_rect_t {
+typedef struct {
 	ui_point_t point;
 	ui_size_t size;
 } ui_rect_t;
 
-typedef struct ui_bitmap_t {
+typedef struct {
 	ui_size_t size;
 	const uint8_t* const data;
 } ui_bitmap_t;
 
-typedef struct ui_font_t {
+typedef struct {
 	const ui_size_t glyph_size;
 	const uint8_t* const data;
 	char c_start;
@@ -60,7 +60,7 @@ typedef struct ui_font_t {
 	size_t data_stride;
 } ui_font_t;
 
-typedef struct portapack_t {
+typedef struct {
 } portapack_t;
 
 void portapack_init(void);

--- a/firmware/common/radio.h
+++ b/firmware/common/radio.h
@@ -215,7 +215,7 @@ typedef enum {
  */
 typedef fp_40_24_t (*sample_rate_fn)(const fp_40_24_t sample_rate, const bool program);
 
-typedef struct radio_t {
+typedef struct {
 	radio_config_mode_t config_mode;
 	uint64_t config[RADIO_NUM_BANKS][RADIO_NUM_REGS];
 	volatile uint32_t regs_dirty;

--- a/firmware/common/rf_path.h
+++ b/firmware/common/rf_path.h
@@ -45,7 +45,7 @@ typedef enum {
 	RF_PATH_FILTER_HIGH_PASS = 2,
 } rf_path_filter_t;
 
-typedef struct rf_path_t {
+typedef struct {
 	uint8_t switchctrl;
 #ifdef HACKRF_ONE
 	gpio_t gpio_hp;

--- a/firmware/common/rffc5071_spi.h
+++ b/firmware/common/rffc5071_spi.h
@@ -27,7 +27,7 @@
 #include "gpio.h"
 #include "spi_bus.h"
 
-typedef struct rffc5071_spi_config_t {
+typedef struct {
 	gpio_t gpio_select;
 	gpio_t gpio_clock;
 	gpio_t gpio_data;

--- a/firmware/common/sgpio.h
+++ b/firmware/common/sgpio.h
@@ -32,7 +32,7 @@ typedef enum {
 	SGPIO_DIRECTION_TX,
 } sgpio_direction_t;
 
-typedef struct sgpio_config_t {
+typedef struct {
 	gpio_t gpio_q_invert;
 #ifndef PRALINE
 	gpio_t gpio_trigger_enable;

--- a/firmware/common/spi_bus.h
+++ b/firmware/common/spi_bus.h
@@ -29,20 +29,20 @@ typedef struct {
 	const size_t count;
 } spi_transfer_t;
 
-struct spi_bus_t; // IWYU pragma: keep - fixed in #1704
-typedef struct spi_bus_t spi_bus_t;
-
-struct spi_bus_t {
+typedef struct _spi_bus_t {
 	void* const obj;
 	const void* config;
-	void (*start)(spi_bus_t* const bus, const void* const config);
-	void (*stop)(spi_bus_t* const bus);
-	void (*transfer)(spi_bus_t* const bus, void* const data, const size_t count);
+	void (*start)(struct _spi_bus_t* const bus, const void* const config);
+	void (*stop)(struct _spi_bus_t* const bus);
+	void (*transfer)(
+		struct _spi_bus_t* const bus,
+		void* const data,
+		const size_t count);
 	void (*transfer_gather)(
-		spi_bus_t* const bus,
+		struct _spi_bus_t* const bus,
 		const spi_transfer_t* const transfers,
 		const size_t count);
-};
+} spi_bus_t;
 
 void spi_bus_start(spi_bus_t* const bus, const void* const config);
 void spi_bus_stop(spi_bus_t* const bus);

--- a/firmware/common/spi_ssp.h
+++ b/firmware/common/spi_ssp.h
@@ -30,7 +30,7 @@
 #include "gpio.h"
 #include "spi_bus.h"
 
-typedef struct ssp_config_t {
+typedef struct {
 	ssp_datasize_t data_bits;
 	ssp_cpol_cpha_t spi_mode;
 	uint8_t serial_clock_rate;

--- a/firmware/common/ui_portapack.c
+++ b/firmware/common/ui_portapack.c
@@ -393,7 +393,7 @@ static ui_point_t portapack_lcd_draw_string(ui_point_t point, const char* s)
 	return point;
 }
 
-typedef struct draw_list_t {
+typedef struct {
 	const ui_bitmap_t* bitmap;
 	const ui_point_t point;
 } draw_list_t;

--- a/firmware/common/usb_queue.h
+++ b/firmware/common/usb_queue.h
@@ -29,27 +29,25 @@
 
 #include "usb_type.h"
 
-typedef struct _usb_transfer_t usb_transfer_t;
-typedef struct _usb_queue_t usb_queue_t;
 typedef void (*transfer_completion_cb)(void*, unsigned int);
 
 // This is an opaque datatype. Thou shall not touch these members.
-struct _usb_transfer_t {
+typedef struct _usb_transfer_t {
 	struct _usb_transfer_t* next;
 	usb_transfer_descriptor_t td ATTR_ALIGNED(64);
 	unsigned int maximum_length;
 	struct _usb_queue_t* queue;
 	transfer_completion_cb completion_cb;
 	void* user_data;
-};
+} usb_transfer_t;
 
 // This is an opaque datatype. Thou shall not touch these members.
-struct _usb_queue_t {
-	struct usb_endpoint_t* endpoint;
+typedef struct _usb_queue_t {
+	usb_endpoint_t* endpoint;
 	const unsigned int pool_size;
 	usb_transfer_t* volatile free_transfers;
 	usb_transfer_t* volatile active;
-};
+} usb_queue_t;
 
 #define USB_DECLARE_QUEUE(endpoint_name) struct _usb_queue_t endpoint_name##_queue;
 #define USB_DEFINE_QUEUE(endpoint_name, _pool_size)                   \

--- a/firmware/common/usb_type.h
+++ b/firmware/common/usb_type.h
@@ -144,15 +144,13 @@ typedef struct {
 	uint8_t* wcid_extended_properties_descriptor;
 } usb_device_t;
 
-typedef struct usb_endpoint_t usb_endpoint_t;
-
-struct usb_endpoint_t {
+typedef struct _usb_endpoint_t {
 	usb_setup_t setup;
 	uint8_t buffer[32]; // Buffer for use during IN stage.
 	const uint_fast8_t address;
 	usb_device_t* const device;
-	usb_endpoint_t* const in;
-	usb_endpoint_t* const out;
-	void (*setup_complete)(usb_endpoint_t* const endpoint);
-	void (*transfer_complete)(usb_endpoint_t* const endpoint);
-};
+	struct _usb_endpoint_t* const in;
+	struct _usb_endpoint_t* const out;
+	void (*setup_complete)(struct _usb_endpoint_t* const endpoint);
+	void (*transfer_complete)(struct _usb_endpoint_t* const endpoint);
+} usb_endpoint_t;

--- a/firmware/common/w25q80bv.h
+++ b/firmware/common/w25q80bv.h
@@ -39,18 +39,15 @@ typedef union {
 	uint8_t id_8b[8];   /* 8*8bits 64bits Unique ID */
 } w25q80bv_unique_id_t;
 
-struct w25q80bv_driver_t; // IWYU pragma: keep - fixed in #1704
-typedef struct w25q80bv_driver_t w25q80bv_driver_t;
-
-struct w25q80bv_driver_t {
+typedef struct _w25q80bv_driver_t {
 	spi_bus_t* bus;
 	gpio_t gpio_hold;
 	gpio_t gpio_wp;
-	void (*target_init)(w25q80bv_driver_t* const drv);
+	void (*target_init)(struct _w25q80bv_driver_t* const drv);
 	size_t page_len;
 	size_t num_pages;
 	size_t num_bytes;
-};
+} w25q80bv_driver_t;
 
 void w25q80bv_setup(w25q80bv_driver_t* const drv);
 void w25q80bv_get_full_status(w25q80bv_driver_t* const drv, uint8_t* data);


### PR DESCRIPTION
Depends on #1703

---

This PR standardizes `struct` definitions for HackRF firmware and resolves the ambiguity between declarations such as `struct type_t` and `typedef struct type_t type_t`

We prefer two formats:

### 1. Simple `struct` definitions:

`struct` definitions of the form:

```c
struct fpga_driver_t;
typedef struct fpga_driver_t fpga_driver_t;

struct fpga_driver_t {
    ice40_spi_driver_t* bus;
    uint8_t regs[FPGA_NUM_REGS];
    uint8_t regs_dirty;
};
```

are refactored to:

```c
typedef struct {
	ice40_spi_driver_t* bus;
	uint8_t regs[FPGA_NUM_REGS];
	uint8_t regs_dirty;
} fpga_driver_t;
```

### 2. Self-referential `struct` definitions:

Self-referential definitions of the form:

```c
struct max5864_driver_t;
typedef struct max5864_driver_t max5864_driver_t;

struct max5864_driver_t {
    spi_bus_t* const bus;
    void (*target_init)(max5864_driver_t* const drv);
};
```

are refactored to:

```c
typedef struct _max5864_driver_t {
    spi_bus_t* const bus;
    void (*target_init)(struct _max5864_driver_t* const drv);
} max5864_driver_t;
```