### PR TITLE
Add include-what-you-use mapping file for libopencm3

### DIFF
--- a/firmware/common/radio.c
+++ b/firmware/common/radio.c
@@ -22,7 +22,6 @@
 #include <string.h>
 
 #include <libopencm3/cm3/nvic.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
 
 #include "fixed_point.h"
 #include "hackrf_core.h"

--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -25,7 +25,6 @@
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/lpc43xx/creg.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/usb.h>
 

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -25,9 +25,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <libopencm3/lpc43xx/ipc.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/cm3/nvic.h>
+#include <libopencm3/lpc43xx/ipc.h>
 
 #include <clkin.h>
 #include <da7219.h>

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -24,7 +24,6 @@
 #include <stddef.h>
 
 #include <libopencm3/cm3/nvic.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
 
 #include <fixed_point.h>
 #include <hackrf_core.h>

--- a/firmware/libopencm3.imp
+++ b/firmware/libopencm3.imp
@@ -1,0 +1,11 @@
+# include-what-you-use mapping file for libopencm3/
+#
+# Usage: include-what-you-use -Xiwyu;--mapping_file=libopencm3.imp
+
+[
+    #  allow libopencm3 to take responsibility for architecture-specific dispatch of nvic.h includes
+    { "include": ["<libopencm3/lpc43xx/m0/nvic.h>",   "private", "<libopencm3/cm3/nvic.h>", "public"] },
+    { "include": ["\"libopencm3/lpc43xx/m0/nvic.h\"", "private", "<libopencm3/cm3/nvic.h>", "public"] },
+    { "include": ["<libopencm3/lpc43xx/m4/nvic.h>",   "private", "<libopencm3/cm3/nvic.h>", "public"] },
+    { "include": ["\"libopencm3/lpc43xx/m4/nvic.h\"", "private", "<libopencm3/cm3/nvic.h>", "public"] },
+]


### PR DESCRIPTION
This PR adds a `include-what-you-use` mapping file for `libopencm3` that allows `libopencm3` to take responsibility for which `nvic.h` headers to include.

This PR has two effects:

1. Prevents `include-what-you-use` from requiring that `hackrf.git` code includes the `<libopencm3/lpc43xx/m4/nvic.h` or `<libopencm3/lpc43xx/m0/nvic.h>` header when using `<libopencm3/cm3/nvic.h>`.
2. Causes `include-what-you-use` to instead require the use of `<libopencm3/cm3/nvic.h>` if the code tries to include a `<libopencm3/lpc43xx/mX/nvic.h>` header.

This works well in practice because: 

> [`libopencm3/cm3/nvic.h`](https://github.com/mossmann/libopencm3/blob/a0bb997968bf57c87f2aa4e389a63219580bb5c3/include/libopencm3/cm3/nvic.h#L129-L135)
```c
/* Note: User interrupts are family specific and are defined in a family
 * specific header file in the corresponding subfolder.
 */


#define WEAK __attribute__((weak))


#include <libopencm3/dispatch/nvic.h>
```

---

Tested with:

```cmake
diff --git a/firmware/CMakeLists.txt b/firmware/CMakeLists.txt
index 10c2d09d..7f170960 100644
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -21,6 +21,15 @@
 # Top directory CMake project for HackRF firmware

 cmake_minimum_required(VERSION 3.10.0)
+
+find_program(IWYU NAMES include-what-you-use)
+if(NOT IWYU)
+  message(FATAL_ERROR "Could not find the program include-what-you-use")
+endif()
+list(APPEND IWYU -Xiwyu;any;-Xiwyu;iwyu;-Xiwyu;args;-m32;-Xiwyu;--error;-Xiwyu;--no_fwd_decls;-Xiwyu;--mapping_file=${CMAKE_SOURCE_DIR}/libopencm3.imp)
+set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU})
+set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU})
+
 set(CMAKE_TOOLCHAIN_FILE toolchain-arm-cortex-m.cmake)

 project (hackrf_firmware_all C)
```