### PR TITLE
Add macros to clarify fixed-point constants.

### DIFF
--- a/firmware/common/fixed_point.h
+++ b/firmware/common/fixed_point.h
@@ -29,8 +29,15 @@ typedef uint64_t fp_40_24_t;
 /* one million in 40.24 fixed-point */
 #define FP_ONE_MHZ ((1000ULL * 1000ULL) << 24)
 
+/* one thousand in 40.24 fixed-point */
+#define FP_ONE_KHZ ((1000ULL) << 24)
+
 /* one in 40.24 fixed-point */
 #define FP_ONE_HZ (1 << 24)
+
+#define FP_MHZ(mhz) (mhz##ULL * FP_ONE_MHZ)
+#define FP_KHZ(khz) (khz##ULL * FP_ONE_KHZ)
+#define FP_HZ(hz)   (hz##ULL * FP_ONE_HZ)
 
 /* 28.36 fixed-point */
 typedef uint64_t fp_28_36_t;
@@ -38,5 +45,12 @@ typedef uint64_t fp_28_36_t;
 /* one million in 28.36 fixed-point */
 #define SR_FP_ONE_MHZ ((1000ULL * 1000ULL) << 36)
 
+/* one thousand in 28.36 fixed-point */
+#define SR_FP_ONE_KHZ (1000ULL << 36)
+
 /* one in 28.36 fixed-point */
 #define SR_FP_ONE_HZ (1ULL << 36)
+
+#define SR_FP_MHZ(mhz) (mhz##ULL * SR_FP_ONE_MHZ)
+#define SR_FP_KHZ(khz) (khz##ULL * SR_FP_ONE_KHZ)
+#define SR_FP_HZ(hz)   (hz##ULL * SR_FP_ONE_HZ)

--- a/firmware/common/fpga_selftest.c
+++ b/firmware/common/fpga_selftest.c
@@ -199,7 +199,7 @@ bool fpga_if_xcvr_selftest(void)
 	max283x_set_frequency(&max283x, 2500000000);
 
 	// Capture 1: 4 Msps, tone at 0.5 MHz, narrowband filter OFF
-	sample_rate_set(4ULL * SR_FP_ONE_MHZ, true);
+	sample_rate_set(SR_FP_MHZ(4), true);
 	delay_us_at_mhz(1000, 204);
 	if (rx_samples(num_samples, 2000000) == -1) {
 		timeout = true;
@@ -222,7 +222,7 @@ bool fpga_if_xcvr_selftest(void)
 
 	// Capture 3: 20 Msps, tone at 5 MHz, narrowband filter OFF
 	fpga_set_tx_nco_pstep(&fpga, 255);
-	sample_rate_set(20ULL * SR_FP_ONE_MHZ, true);
+	sample_rate_set(SR_FP_MHZ(20), true);
 	narrowband_filter_set(0);
 	delay_us_at_mhz(1000, 204);
 	if (rx_samples(num_samples, 2000000) == -1) {
@@ -245,7 +245,7 @@ bool fpga_if_xcvr_selftest(void)
 		&selftest.xcvr_measurements[3]);
 
 	// Restore default settings.
-	sample_rate_set(10ULL * SR_FP_ONE_MHZ, true);
+	sample_rate_set(SR_FP_MHZ(10), true);
 	rf_path_set_direction(&rf_path, RF_PATH_DIRECTION_OFF);
 	narrowband_filter_set(0);
 	fpga_init(&fpga);

--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -688,7 +688,7 @@ void clock_gen_init(void)
 	/* MS7/CLK7 is unused. */
 
 	/* Set to 10 MHz, the common rate between Jawbreaker and HackRF One. */
-	sample_rate_set(10ULL * SR_FP_ONE_MHZ, true);
+	sample_rate_set(SR_FP_MHZ(10), true);
 
 	si5351c_configure_clock_control(&clock_gen);
 	si5351c_set_clock_source(&clock_gen, PLL_SOURCE_XTAL);

--- a/firmware/common/radio.c
+++ b/firmware/common/radio.c
@@ -151,9 +151,9 @@ static inline uint8_t compute_resample_log(
 	return n;
 }
 
-#define MIN_MCU_RATE     (200000ULL * SR_FP_ONE_HZ)
-#define MAX_MCU_RATE     (21800000ULL * SR_FP_ONE_HZ)
-#define DEFAULT_MCU_RATE (10000000ULL * SR_FP_ONE_HZ)
+#define MIN_MCU_RATE     SR_FP_KHZ(200)
+#define MAX_MCU_RATE     SR_FP_KHZ(21800)
+#define DEFAULT_MCU_RATE SR_FP_KHZ(10000)
 
 static fp_28_36_t applied_afe_rate = RADIO_UNSET;
 
@@ -240,7 +240,7 @@ static bool radio_update_sample_rate(radio_t* const radio, uint64_t* bank)
 	return (new_afe_rate || new_rate || new_n);
 }
 
-#define DEFAULT_RF (2450ULL * FP_ONE_MHZ)
+#define DEFAULT_RF FP_MHZ(2450)
 
 static fp_28_36_t applied_offset = RADIO_UNSET;
 


### PR DESCRIPTION
It's not very clear at a glance what order of magnitude e.g. `21800000ULL * SR_FP_ONE_HZ` is, so add some macros for defining constants in each fixed-point format in Hz, kHz or MHz.