### PR TITLE
Correct GPIO pin assignments for CPLD JTAG on Jawbreaker.

### DIFF
--- a/firmware/common/hackrf_core.c
+++ b/firmware/common/hackrf_core.c
@@ -947,7 +947,7 @@ void pin_setup(void)
 #endif
 
 	jtag_gpio_cpld.gpio_tck = gpio->cpld_tck;
-#if defined(HACKRF_ONE) || defined(RAD1O)
+#if defined(HACKRF_ONE) || defined(RAD1O) || defined(JAWBREAKER)
 	jtag_gpio_cpld.gpio_tms = gpio->cpld_tms;
 	jtag_gpio_cpld.gpio_tdi = gpio->cpld_tdi;
 	jtag_gpio_cpld.gpio_tdo = gpio->cpld_tdo;

--- a/firmware/common/platform_gpio.c
+++ b/firmware/common/platform_gpio.c
@@ -131,16 +131,21 @@ const platform_gpio_t* platform_gpio(void)
 #endif
 
 	/* CPLD JTAG interface GPIO pins_FPGA config pins in Praline */
-	gpio.cpld_tck       = &GPIO3_0;
+	gpio.cpld_tck        = &GPIO3_0;
 #if defined(PRALINE)
 	gpio.fpga_cfg_creset = &GPIO2_11;
 	gpio.fpga_cfg_cdone  = &GPIO5_14;
 	gpio.fpga_cfg_spi_cs = &GPIO2_10;
+#else
+	gpio.cpld_tdo        = &GPIO5_18;
 #endif
 #if defined(HACKRF_ONE) || defined(RAD1O)
-	gpio.cpld_tdo        = &GPIO5_18;
 	gpio.cpld_tms        = &GPIO3_4;
 	gpio.cpld_tdi        = &GPIO3_1;
+#endif
+#if defined(JAWBREAKER)
+	gpio.cpld_tms        = &GPIO3_1;
+	gpio.cpld_tdi        = &GPIO3_4;
 #endif
 #if defined(HACKRF_ONE) || defined(PRALINE)
 	gpio.cpld_pp_tms     = &GPIO1_1;

--- a/firmware/common/platform_gpio.h
+++ b/firmware/common/platform_gpio.h
@@ -109,7 +109,7 @@ typedef struct {
 
 	/* CPLD JTAG interface GPIO pins, FPGA config pins in Praline */
 	gpio_t cpld_tck;
-#if defined(HACKRF_ONE) || defined(RAD1O)
+#if defined(HACKRF_ONE) || defined(RAD1O) || defined(JAWBREAKER)
 	gpio_t cpld_tdo;
 	gpio_t cpld_tms;
 	gpio_t cpld_tdi;

--- a/firmware/common/platform_scu.c
+++ b/firmware/common/platform_scu.c
@@ -85,11 +85,14 @@ const platform_scu_t* platform_scu(void)
 	scu.PINMUX_FPGA_CRESET = (P5_2);  /* GPIO2[11] on P5_2 */
 	scu.PINMUX_FPGA_CDONE  = (P4_10); /* GPIO5[14] */
 	scu.PINMUX_FPGA_SPI_CS = (P5_1);  /* GPIO2[10] */
-#elif defined(RAD1O) || defined(HACKRF_ONE)
+#else
+	scu.PINMUX_CPLD_TDO    = (P9_5);  /* GPIO5[18] */
+#endif
+#if defined(RAD1O) || defined(HACKRF_ONE)
 	scu.PINMUX_CPLD_TMS    = (P6_5);  /* GPIO3[ 4] */
 	scu.PINMUX_CPLD_TDI    = (P6_2);  /* GPIO3[ 1] */
-	scu.PINMUX_CPLD_TDO    = (P9_5);  /* GPIO5[18] */
-#else
+#endif
+#if defined(JAWBREAKER)
 	scu.PINMUX_CPLD_TMS    = (P6_2);  /* GPIO3[ 1] */
 	scu.PINMUX_CPLD_TDI    = (P6_5);  /* GPIO3[ 4] */
 #endif


### PR DESCRIPTION
Possibly fix #1732.