### PR TITLE
By default, turn off bias tee when radio idle

### DIFF
--- a/firmware/common/radio.c
+++ b/firmware/common/radio.c
@@ -53,6 +53,7 @@ void radio_init(radio_t* const radio)
 	radio->config[RADIO_BANK_IDLE][RADIO_OPMODE] = TRANSCEIVER_MODE_OFF;
 	radio->config[RADIO_BANK_RX][RADIO_OPMODE] = TRANSCEIVER_MODE_RX;
 	radio->config[RADIO_BANK_TX][RADIO_OPMODE] = TRANSCEIVER_MODE_TX;
+	radio->config[RADIO_BANK_IDLE][RADIO_BIAS_TEE] = false;
 	radio->regs_dirty = 0;
 }
 


### PR DESCRIPTION
This matches the behavior before #1648.