### PR TITLE
Round displayed values to nearest kHz in rad1o UI

### DIFF
--- a/firmware/common/ui_rad1o.c
+++ b/firmware/common/ui_rad1o.c
@@ -58,11 +58,14 @@ static bool enabled = false;
 #define WHITE      0b11111111
 #define GREY       0b01001101
 
+#define DIV_ROUND_CLOSEST(n, d) ((n + (d / 2)) / d)
+
 static void print_hz(char* tmp, char* fmt, uint64_t hz)
 {
 	uint32_t mhz, khz;
-	mhz = hz / 1000000;
-	khz = (hz - mhz * 1000000) / 1000;
+	mhz = DIV_ROUND_CLOSEST(hz, 1000000);
+	hz -= mhz * 1000000;
+	khz = DIV_ROUND_CLOSEST(hz, 1000);
 	sprintf(tmp, fmt, (unsigned int) mhz, (unsigned int) khz);
 	rad1o_lcdPrint(tmp);
 }

--- a/firmware/common/ui_rad1o.c
+++ b/firmware/common/ui_rad1o.c
@@ -30,9 +30,6 @@
 #include "drivers.h"
 #include "rf_path.h"
 #include "transceiver_mode.h"
-#ifdef IS_NOT_RAD1O
-	#include "radio.h"
-#endif
 
 #include "rad1o/display.h"
 #include "rad1o/draw.h"

--- a/firmware/common/ui_rad1o.c
+++ b/firmware/common/ui_rad1o.c
@@ -58,20 +58,21 @@ static bool enabled = false;
 #define WHITE      0b11111111
 #define GREY       0b01001101
 
+static void print_hz(char* tmp, char* fmt, uint64_t hz)
+{
+	uint32_t mhz, khz;
+	mhz = hz / 1000000;
+	khz = (hz - mhz * 1000000) / 1000;
+	sprintf(tmp, fmt, (unsigned int) mhz, (unsigned int) khz);
+	rad1o_lcdPrint(tmp);
+}
+
 static void draw_frequency(void)
 {
 	char tmp[100];
-	uint32_t mhz;
-	uint32_t khz;
-
-	mhz = freq / 1000000;
-	khz = (freq - mhz * 1000000) / 1000;
-
 	rad1o_setTextColor(BLACK, GREEN);
 	rad1o_setIntFont(&Font_Ubuntu18pt);
-	sprintf(tmp, "%4u.%03u", (unsigned int) mhz, (unsigned int) khz);
-	rad1o_lcdPrint(tmp);
-
+	print_hz(tmp, "%4u.%03u", freq);
 	rad1o_setIntFont(&Font_7x8);
 	rad1o_lcdMoveCrsr(1, 18 - 7);
 	rad1o_lcdPrint("MHz");
@@ -112,8 +113,6 @@ static void draw_tx_rx(void)
 static void ui_update(void)
 {
 	char tmp[100];
-	uint32_t mhz;
-	uint32_t khz;
 
 	if (!enabled) {
 		return;
@@ -154,18 +153,12 @@ static void ui_update(void)
 	rad1o_setTextColor(BLACK, WHITE);
 	rad1o_lcdSetCrsr(2, 71);
 	rad1o_lcdPrint("Rate:   ");
-	mhz = sample_rate / 1000000;
-	khz = (sample_rate - mhz * 1000000) / 1000;
-	sprintf(tmp, "%2u.%03u MHz", (unsigned int) mhz, (unsigned int) khz);
-	rad1o_lcdPrint(tmp);
+	print_hz(tmp, "%2u.%03u MHz", sample_rate);
 	rad1o_lcdNl();
 
 	rad1o_lcdMoveCrsr(2, 0);
 	rad1o_lcdPrint("Filter: ");
-	mhz = filter_bw / 1000000;
-	khz = (filter_bw - mhz * 1000000) / 1000;
-	sprintf(tmp, "%2u.%03u MHz", (unsigned int) mhz, (unsigned int) khz);
-	rad1o_lcdPrint(tmp);
+	print_hz(tmp, "%2u.%03u MHz", filter_bw);
 	rad1o_lcdNl();
 
 	rad1o_drawHLine(88, 0, RESX - 1, WHITE);


### PR DESCRIPTION
Fixes #1743.

The rad1o UI displays values to the nearest kHz only, so round correctly to that precision for display.