### PR TITLE
Improve pins_shutdown()

### DIFF
--- a/firmware/common/operacake_sctimer.c
+++ b/firmware/common/operacake_sctimer.c
@@ -28,6 +28,7 @@
 
 #include "delay.h"
 #include "platform_detect.h"
+#include "platform_scu.h"
 #include "sct.h"
 
 #ifdef IS_NOT_PRALINE
@@ -62,6 +63,8 @@ static uint32_t default_output = 0;
  */
 void operacake_sctimer_init(void)
 {
+	const platform_scu_t* scu = platform_scu();
+
 	// We start by resetting the SCTimer
 	RESET_CTRL1 = RESET_CTRL1_SCT_RST;
 
@@ -77,25 +80,15 @@ void operacake_sctimer_init(void)
 
 	// Pin definitions for the HackRF
 	// U2CTRL0
-	scu_pinmux(
-		P7_4,
-		SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
+	scu_pinmux(scu->CTOUT_13, scu->CTOUT_PINCFG);
 	// U2CTRL1
-	scu_pinmux(
-		P7_5,
-		SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
+	scu_pinmux(scu->CTOUT_12, scu->CTOUT_PINCFG);
 	// U3CTRL0
-	scu_pinmux(
-		P7_6,
-		SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
+	scu_pinmux(scu->CTOUT_11, scu->CTOUT_PINCFG);
 	// U3CTRL1
-	scu_pinmux(
-		P7_7,
-		SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
+	scu_pinmux(scu->CTOUT_8, scu->CTOUT_PINCFG);
 	// U1CTRL
-	scu_pinmux(
-		P7_0,
-		SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
+	scu_pinmux(scu->CTOUT_14, scu->CTOUT_PINCFG);
 
 	uint8_t sct_clock_input;
 #ifdef IS_NOT_PRALINE
@@ -114,8 +107,8 @@ void operacake_sctimer_init(void)
 #endif
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
-		// Configure pin P6_4 as SCT_IN_6
-		scu_pinmux(P6_4, SCU_CLK_IN | SCU_CONF_FUNCTION1);
+		// Configure pin P6_4 as CTIN_6
+		scu_pinmux(scu->SCT_CLK, scu->SCT_CLK_PINCFG);
 
 		// Use the GIMA to connect MS0/CLK1 (SCT_CLK) on pin P6_4 to the SCTimer
 		GIMA_CTIN_6_IN = 0x0 << 4;

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -178,9 +178,30 @@ void pins_shutdown(void)
 		scu_pinmux(scu->TRIGGER_IN, scu->TRIGGER_IN_PINCFG);
 		scu_pinmux(scu->TRIGGER_OUT, scu->TRIGGER_OUT_PINCFG);
 		scu_pinmux(scu->PPS_OUT, scu->PPS_OUT_PINCFG);
-		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
-		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->SCT_CLK, scu->SCT_CLK_PINCFG);
+
+		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		scu_pinmux(scu->SSP1_CIPO, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->SSP1_COPI, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->SSP1_SCK, SCU_GPIO_PDN | SCU_CONF_FUNCTION2);
+
+		scu_pinmux(scu->XCVR_ENABLE, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->XCVR_RXENABLE, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->XCVR_CS, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->XCVR_RXHP, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->XCVR_LD, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		scu_pinmux(scu->MIXER_LD, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->MIXER_SCLK, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->MIXER_SDATA, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->MIXER_ENX, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->MIXER_RESETX, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->MIXER_ENBL, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		scu_pinmux(scu->AD_CS, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
 
 		p2_ctrl_set(P2_SIGNAL_CLK3);
 		p1_ctrl_set(P1_SIGNAL_CLKIN);
@@ -202,8 +223,12 @@ void pins_shutdown(void)
 		gpio_clear(gpio->fpga_cfg_creset);
 		gpio_output(gpio->fpga_cfg_creset);
 		gpio_input(gpio->fpga_cfg_cdone);
+		gpio_input(gpio->max5864_select);
+
+		rf_path_pin_shutdown();
 	}
 #endif
+	sgpio_pin_shutdown(&sgpio_config);
 
 	/* enable input on SCL and SDA pins */
 	SCU_SFSI2C0 = SCU_I2C0_NOMINAL;
@@ -360,6 +385,9 @@ void pins_setup(void)
 		    (detected_revision() == BOARD_REV_GSG_PRALINE_R1_0)) {
 			rf_path.gpio_mix_en_n = gpio->mix_en_n_r1_0;
 		}
+		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
 	}
 #endif
 

--- a/firmware/common/platform_gpio.c
+++ b/firmware/common/platform_gpio.c
@@ -234,6 +234,7 @@ const platform_gpio_t* platform_gpio(void)
 		gpio.rffc5072_data   = &GPIO4_14;
 		gpio.rffc5072_reset  = &GPIO2_14;
 		gpio.rffc5072_ld     = &GPIO6_25;
+		gpio.rffc5072_enbl   = &GPIO4_12;
 	}
 #endif
 

--- a/firmware/common/platform_gpio.h
+++ b/firmware/common/platform_gpio.h
@@ -137,6 +137,7 @@ typedef struct {
 	gpio_t rffc5072_data;
 	gpio_t rffc5072_reset;
 	gpio_t rffc5072_ld;   // PRALINE
+	gpio_t rffc5072_enbl; // PRALINE
 	gpio_t vco_ce;        // RAD1O
 	gpio_t vco_sclk;      // RAD1O
 	gpio_t vco_sdata;     // RAD1O

--- a/firmware/common/platform_scu.c
+++ b/firmware/common/platform_scu.c
@@ -258,10 +258,12 @@ const platform_scu_t* platform_scu(void)
 		scu.MIXER_SDATA  = (P9_2);  /* GPIO4[14] on P9_2 */
 		scu.MIXER_RESETX = (P5_5);  /* GPIO2[14] on P5_5 */
 		scu.MIXER_LD     = (PD_11); /* GPIO6[25] on PD_11 */
+		scu.MIXER_ENBL   = (P9_0);  /* GPIO4[12] on P9_0 */
 
 		scu.MIXER_SCLK_PINCFG  = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
 		scu.MIXER_SDATA_PINCFG = (SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 		scu.MIXER_LD_PINCFG    = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
+		scu.MIXER_ENBL_PINCFG  = (SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 	}
 #endif
 #ifdef IS_RAD1O
@@ -365,6 +367,7 @@ const platform_scu_t* platform_scu(void)
 		scu.TRIGGER_IN  = (PD_12); /* GPIO6[26] on PD_12 */
 		scu.TRIGGER_OUT = (P2_6);  /* GPIO5[6] on P2_6 */
 		scu.PPS_OUT     = (P2_5);  /* GPIO5[5] on P2_5 */
+		scu.SCT_CLK     = (P6_4);  /* CTIN_6 on P6_4 */
 
 		scu.P2_CTRL0_PINCFG    = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
 		scu.P2_CTRL1_PINCFG    = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
@@ -376,6 +379,7 @@ const platform_scu_t* platform_scu(void)
 		scu.TRIGGER_IN_PINCFG  = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
 		scu.TRIGGER_OUT_PINCFG = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
 		scu.PPS_OUT_PINCFG     = (SCU_GPIO_FAST | SCU_CONF_FUNCTION4);
+		scu.SCT_CLK_PINCFG     = (SCU_CLK_IN | SCU_CONF_FUNCTION1);
 	}
 #endif
 
@@ -437,6 +441,14 @@ const platform_scu_t* platform_scu(void)
 		scu.PINMUX_GPIO3_15 = (P7_7);  /* GPIO3[15] */
 	}
 #endif
+
+	/* SCT */
+	scu.CTOUT_8  = (P7_7);
+	scu.CTOUT_11 = (P7_6);
+	scu.CTOUT_12 = (P7_5);
+	scu.CTOUT_13 = (P7_4);
+	scu.CTOUT_14 = (P7_0);
+	scu.CTOUT_PINCFG  = (SCU_CONF_EPUN_DIS_PULLUP | SCU_CONF_EHS_FAST | SCU_CONF_FUNCTION1);
 
 	scu.PINMUX_ISP = (P2_7);  /* GPIO0[7] */
 

--- a/firmware/common/platform_scu.h
+++ b/firmware/common/platform_scu.h
@@ -157,7 +157,9 @@ typedef struct {
 #endif
 #ifdef IS_PRALINE
 	scu_grp_pin_t MIXER_LD;
+	scu_grp_pin_t MIXER_ENBL;
 	uint32_t MIXER_LD_PINCFG;
+	uint32_t MIXER_ENBL_PINCFG;
 #endif
 #ifdef IS_RAD1O
 	scu_grp_pin_t VCO_CE;
@@ -240,6 +242,7 @@ typedef struct {
 	scu_grp_pin_t TRIGGER_IN;
 	scu_grp_pin_t TRIGGER_OUT;
 	scu_grp_pin_t PPS_OUT;
+	scu_grp_pin_t SCT_CLK;
 
 	scu_grp_pin_t P2_CTRL0_PINCFG;
 	scu_grp_pin_t P2_CTRL1_PINCFG;
@@ -251,6 +254,7 @@ typedef struct {
 	scu_grp_pin_t TRIGGER_IN_PINCFG;
 	scu_grp_pin_t TRIGGER_OUT_PINCFG;
 	scu_grp_pin_t PPS_OUT_PINCFG;
+	scu_grp_pin_t SCT_CLK_PINCFG;
 #endif
 
 	/* HackRF One r9 */
@@ -299,6 +303,14 @@ typedef struct {
 	scu_grp_pin_t PINMUX_PP_ADDR;
 	scu_grp_pin_t PINMUX_U0_TXD;
 	scu_grp_pin_t PINMUX_U0_RXD;
+
+	/* SCT */
+	scu_grp_pin_t CTOUT_8;
+	scu_grp_pin_t CTOUT_11;
+	scu_grp_pin_t CTOUT_12;
+	scu_grp_pin_t CTOUT_13;
+	scu_grp_pin_t CTOUT_14;
+	scu_grp_pin_t CTOUT_PINCFG;
 
 	scu_grp_pin_t PINMUX_ISP;
 

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -317,6 +317,33 @@ static void switchctrl_set(rf_path_t* const rf_path, const uint8_t gpo)
 #endif
 }
 
+void rf_path_pin_shutdown(void)
+{
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		const platform_scu_t* scu = platform_scu();
+
+		/* Configure RF switch control signals */
+		scu_pinmux(scu->TX_EN, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		board_rev_t rev = detected_revision();
+		if ((rev == BOARD_REV_PRALINE_R1_0) ||
+		    (rev == BOARD_REV_GSG_PRALINE_R1_0)) {
+			scu_pinmux(scu->MIX_EN_N_R1_0, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		} else {
+			scu_pinmux(scu->MIX_EN_N, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		}
+		scu_pinmux(scu->LPF_EN, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->RF_AMP_EN, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		/* Configure antenna port power control signal */
+		scu_pinmux(scu->ANT_BIAS_EN_N, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		/* Configure RF power supply (VAA) switch */
+		scu_pinmux(scu->NO_VAA_ENABLE, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+	}
+#endif
+}
+
 void rf_path_pin_setup(rf_path_t* const rf_path)
 {
 #ifdef IS_JAWBREAKER

--- a/firmware/common/rf_path.h
+++ b/firmware/common/rf_path.h
@@ -93,6 +93,7 @@ typedef struct {
 	};
 } rf_path_t;
 
+void rf_path_pin_shutdown(void);
 void rf_path_pin_setup(rf_path_t* const rf_path);
 void rf_path_init(rf_path_t* const rf_path);
 

--- a/firmware/common/sgpio.c
+++ b/firmware/common/sgpio.c
@@ -37,6 +37,53 @@
 
 static void update_q_invert(sgpio_config_t* const config);
 
+void sgpio_pin_shutdown(sgpio_config_t* const config)
+{
+	const platform_scu_t* scu = platform_scu();
+
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		scu_pinmux(scu->PINMUX_SGPIO0, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO1, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO2, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO3, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO4, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_SGPIO5, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO6, SCU_GPIO_PDN | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_SGPIO7, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO8, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO9, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO10, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO11, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_SGPIO12, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+	}
+#endif
+
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		scu_pinmux(
+			scu->H1R9_TRIGGER_EN,
+			SCU_GPIO_PDN | SCU_CONF_FUNCTION4); /* GPIO5[5] */
+	}
+#endif
+#ifdef IS_NOT_H1_R9
+	if (IS_NOT_H1_R9) {
+		scu_pinmux(
+			scu->TRIGGER_EN,
+			SCU_GPIO_PDN | SCU_CONF_FUNCTION4); /* GPIO5[12] */
+	}
+#endif
+
+	gpio_input(config->gpio_q_invert);
+
+#ifdef IS_NOT_PRALINE
+	if (IS_NOT_PRALINE) {
+		trigger_enable(false);
+		gpio_output(config->gpio_trigger_enable);
+	}
+#endif
+}
+
 void sgpio_configure_pin_functions(sgpio_config_t* const config)
 {
 	const platform_scu_t* scu = platform_scu();

--- a/firmware/common/sgpio.h
+++ b/firmware/common/sgpio.h
@@ -41,6 +41,7 @@ typedef struct {
 	bool slice_mode_multislice;
 } sgpio_config_t;
 
+void sgpio_pin_shutdown(sgpio_config_t* const config);
 void sgpio_configure_pin_functions(sgpio_config_t* const config);
 void sgpio_test_interface(sgpio_config_t* const config);
 void sgpio_set_slice_mode(sgpio_config_t* const config, const bool multi_slice);


### PR DESCRIPTION
Pull down more pins in pins_shutdown() to reduce leakage current that can interfere with power sequencing and FPGA configuration on some Pralines.

Fix #1696 