### PR TITLE
libhackrf: Set timeouts for all USB transfers

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -54,6 +54,10 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 	#define FROM_LE64(x) x
 #endif
 
+#define DEFAULT_REQUEST_TIMEOUT 100
+#define CPLD_WRITE_TIMEOUT      10000
+#define SPIFLASH_WRITE_TIMEOUT  50000 // W25Q32JV max chip erase time
+
 // TODO: Factor this into a shared #include so that firmware can use
 // the same values.
 typedef enum {
@@ -778,7 +782,7 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 			0,
 			(unsigned char*) &buffer_size,
 			4,
-			0);
+			DEFAULT_REQUEST_TIMEOUT);
 
 		if (result < 4) {
 			last_libusb_error = result;
@@ -948,7 +952,7 @@ int ADDCALL hackrf_set_transceiver_mode(
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -977,7 +981,7 @@ int ADDCALL hackrf_max2837_read(
 		register_number,
 		(unsigned char*) value,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 2) {
 		last_libusb_error = result;
@@ -1006,7 +1010,7 @@ int ADDCALL hackrf_max2831_read(
 		register_number,
 		(unsigned char*) value,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 2) {
 		last_libusb_error = result;
@@ -1039,7 +1043,7 @@ int ADDCALL hackrf_max2837_write(
 		register_number,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1072,7 +1076,7 @@ int ADDCALL hackrf_max2831_write(
 		register_number,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1103,7 +1107,7 @@ int ADDCALL hackrf_si5351c_read(
 		register_number,
 		(unsigned char*) &temp_value,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -1137,7 +1141,7 @@ int ADDCALL hackrf_si5351c_write(
 		register_number,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1161,7 +1165,7 @@ int ADDCALL hackrf_set_baseband_filter_bandwidth(
 		bandwidth_hz >> 16,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1190,7 +1194,7 @@ int ADDCALL hackrf_rffc5071_read(
 		register_number,
 		(unsigned char*) value,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 2) {
 		last_libusb_error = result;
@@ -1220,7 +1224,7 @@ int ADDCALL hackrf_rffc5071_write(
 		register_number,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1246,7 +1250,7 @@ int ADDCALL hackrf_fpga_read_register(
 		register_number,
 		(unsigned char*) value,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -1273,7 +1277,7 @@ int ADDCALL hackrf_fpga_write_register(
 		register_number,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1297,7 +1301,7 @@ int ADDCALL hackrf_read_selftest(hackrf_device* device, hackrf_selftest* selftes
 		0,
 		(unsigned char*) selftest,
 		sizeof(hackrf_selftest),
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 2) {
 		last_libusb_error = result;
@@ -1429,7 +1433,7 @@ int ADDCALL hackrf_read_adc(hackrf_device* device, uint8_t adc_channel, uint16_t
 		adc_channel,
 		(unsigned char*) value,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 2) {
 		last_libusb_error = result;
@@ -1453,7 +1457,7 @@ int ADDCALL hackrf_get_m0_state(hackrf_device* device, hackrf_m0_state* state)
 		0,
 		(unsigned char*) state,
 		sizeof(hackrf_m0_state),
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < sizeof(hackrf_m0_state)) {
 		last_libusb_error = result;
@@ -1488,7 +1492,7 @@ int ADDCALL hackrf_set_tx_underrun_limit(hackrf_device* device, uint32_t value)
 		value >> 16,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1512,7 +1516,7 @@ int ADDCALL hackrf_set_rx_overrun_limit(hackrf_device* device, uint32_t value)
 		value >> 16,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1534,7 +1538,7 @@ int ADDCALL hackrf_spiflash_erase(hackrf_device* device)
 		0,
 		NULL,
 		0,
-		0);
+		SPIFLASH_WRITE_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1565,7 +1569,7 @@ int ADDCALL hackrf_spiflash_write(
 		address & 0xFFFF,
 		data,
 		length,
-		0);
+		SPIFLASH_WRITE_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -1595,7 +1599,7 @@ int ADDCALL hackrf_spiflash_read(
 		address & 0xFFFF,
 		data,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -1618,7 +1622,7 @@ int ADDCALL hackrf_spiflash_status(hackrf_device* device, uint8_t* data)
 		0,
 		data,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -1641,7 +1645,7 @@ int ADDCALL hackrf_spiflash_clear_status(hackrf_device* device)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1671,8 +1675,7 @@ int ADDCALL hackrf_cpld_write(
 			&data[i],
 			chunk_size,
 			&transferred,
-			10000 // long timeout to allow for CPLD programming
-		);
+			CPLD_WRITE_TIMEOUT);
 
 		if (result != LIBUSB_SUCCESS) {
 			last_libusb_error = result;
@@ -1694,7 +1697,7 @@ int ADDCALL hackrf_board_id_read(hackrf_device* device, uint8_t* value)
 		0,
 		value,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -1718,7 +1721,7 @@ int ADDCALL hackrf_version_string_read(
 		0,
 		(unsigned char*) version,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 0) {
 		last_libusb_error = result;
@@ -1769,7 +1772,7 @@ int ADDCALL hackrf_set_freq(hackrf_device* device, const uint64_t freq_hz)
 		0,
 		(unsigned char*) &set_freq_params,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -1829,7 +1832,7 @@ int ADDCALL hackrf_set_freq_explicit(
 		0,
 		(unsigned char*) &params,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -1871,7 +1874,7 @@ int ADDCALL hackrf_set_sample_rate_manual(
 		0,
 		(unsigned char*) &set_fracrate_params,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -1943,7 +1946,7 @@ int ADDCALL hackrf_set_amp_enable(hackrf_device* device, const uint8_t value)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -1969,7 +1972,7 @@ int ADDCALL hackrf_board_partid_serialno_read(
 		0,
 		(unsigned char*) read_partid_serialno,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -2010,7 +2013,7 @@ int ADDCALL hackrf_set_lna_gain(hackrf_device* device, uint32_t value)
 		value,
 		&retval,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 1 || !retval) {
 		return HACKRF_ERROR_INVALID_PARAM;
@@ -2037,7 +2040,7 @@ int ADDCALL hackrf_set_vga_gain(hackrf_device* device, uint32_t value)
 		value,
 		&retval,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 1 || !retval) {
 		return HACKRF_ERROR_INVALID_PARAM;
@@ -2063,7 +2066,7 @@ int ADDCALL hackrf_set_txvga_gain(hackrf_device* device, uint32_t value)
 		value,
 		&retval,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 1 || !retval) {
 		return HACKRF_ERROR_INVALID_PARAM;
@@ -2084,7 +2087,7 @@ int ADDCALL hackrf_set_antenna_enable(hackrf_device* device, const uint8_t value
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -2401,7 +2404,7 @@ ADDAPI int ADDCALL hackrf_enable_tx_flush(
 		device->buffer_size,
 		hackrf_libusb_flush_callback,
 		device,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	device->flush_transfer->flags = LIBUSB_TRANSFER_FREE_BUFFER;
 
@@ -2669,7 +2672,7 @@ int ADDCALL hackrf_set_hw_sync_mode(hackrf_device* device, const uint8_t value)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -2750,7 +2753,7 @@ int ADDCALL hackrf_init_sweep(
 		(num_bytes >> 16) & 0xffff,
 		data,
 		size,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < size) {
 		last_libusb_error = result;
@@ -2784,7 +2787,7 @@ int ADDCALL hackrf_get_operacake_boards(hackrf_device* device, uint8_t* boards)
 		0,
 		boards,
 		8,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 8) {
 		last_libusb_error = result;
@@ -2823,7 +2826,7 @@ int ADDCALL hackrf_set_operacake_mode(
 		(uint8_t) mode,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -2862,7 +2865,7 @@ int ADDCALL hackrf_get_operacake_mode(
 		0,
 		&buf,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -2905,7 +2908,7 @@ int ADDCALL hackrf_set_operacake_ports(
 		port_a | (port_b << 8),
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -2927,7 +2930,7 @@ int ADDCALL hackrf_reset(hackrf_device* device)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -2957,7 +2960,7 @@ int ADDCALL hackrf_set_operacake_ranges(
 		0,
 		ranges,
 		len_ranges,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < len_ranges) {
 		last_libusb_error = result;
@@ -2998,7 +3001,7 @@ int ADDCALL hackrf_set_operacake_freq_ranges(
 		0,
 		range_bytes,
 		len_ranges,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < len_ranges) {
 		last_libusb_error = result;
@@ -3040,7 +3043,7 @@ int ADDCALL hackrf_set_operacake_dwell_times(
 		0,
 		dwell_data,
 		data_len,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < data_len) {
 		last_libusb_error = result;
@@ -3063,7 +3066,7 @@ int ADDCALL hackrf_set_clkout_enable(hackrf_device* device, const uint8_t value)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3085,7 +3088,7 @@ int ADDCALL hackrf_get_clkin_status(hackrf_device* device, uint8_t* status)
 		0,
 		status,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 	if (result < 1) {
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
@@ -3114,7 +3117,7 @@ int ADDCALL hackrf_operacake_gpio_test(
 		0,
 		(unsigned char*) test_result,
 		2,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -3140,7 +3143,7 @@ int ADDCALL hackrf_cpld_checksum(hackrf_device* device, uint32_t* crc)
 		0,
 		(unsigned char*) crc,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < length) {
 		last_libusb_error = result;
@@ -3165,7 +3168,7 @@ int ADDCALL hackrf_set_ui_enable(hackrf_device* device, const uint8_t value)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3223,7 +3226,7 @@ int ADDCALL hackrf_board_rev_read(hackrf_device* device, uint8_t* value)
 		0,
 		value,
 		1,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -3307,7 +3310,7 @@ int ADDCALL hackrf_supported_platform_read(hackrf_device* device, uint32_t* valu
 		0,
 		&data[0],
 		4,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 1) {
 		last_libusb_error = result;
@@ -3330,7 +3333,7 @@ int ADDCALL hackrf_set_leds(hackrf_device* device, const uint8_t state)
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3376,7 +3379,7 @@ int ADDCALL hackrf_set_user_bias_t_opts(
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3399,7 +3402,7 @@ int ADDCALL hackrf_set_p1_ctrl(hackrf_device* device, const enum p1_ctrl_signal 
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3422,7 +3425,7 @@ int ADDCALL hackrf_set_p2_ctrl(hackrf_device* device, const enum p2_ctrl_signal 
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3447,7 +3450,7 @@ int ADDCALL hackrf_set_clkin_ctrl(
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3470,7 +3473,7 @@ int ADDCALL hackrf_set_narrowband_filter(hackrf_device* device, const uint8_t va
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3493,7 +3496,7 @@ int ADDCALL hackrf_set_fpga_bitstream(hackrf_device* device, const uint8_t index
 		0,
 		NULL,
 		0,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;
@@ -3521,7 +3524,7 @@ int ADDCALL hackrf_radio_read_register(
 		bank,
 		(unsigned char*) value,
 		length,
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 	*value = FROM_LE64(*value);
 
 	if (result < length) {
@@ -3561,7 +3564,7 @@ int ADDCALL hackrf_radio_write_register(
 		bank,
 		&data[0],
 		sizeof(data),
-		0);
+		DEFAULT_REQUEST_TIMEOUT);
 
 	if (result < 9) {
 		last_libusb_error = result;


### PR DESCRIPTION
Currently, libhackrf makes many USB control requests with no timeout set. If those requests fail to complete for any reason other than a device disconnect, libhackrf will hang indefinitely.

This PR sets timeouts for all USB transfers, with a default of 100ms for most USB requests, and longer times for CPLD writes (10 seconds, unchanged) and SPI flash erase/writes (50 seconds, per W25Q32JV datasheet).