### PR TITLE
Further work on Si5351 driver

### DIFF
--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,12 +51,6 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
-uint8_t clkout_id;
-uint8_t mcu_clkin_id;
-
-static bool input_initialized = false;
-static si5351c_input_t active_input;
-
 /* write to single register */
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val)
 {
@@ -290,7 +284,7 @@ void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (drv->clk[clkout_id].output_enable) {
+		if (drv->clk[drv->clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -310,7 +304,7 @@ void si5351c_set_int_mode(
 
 void si5351c_change_input(si5351c_driver_t* const drv, si5351c_input_t input)
 {
-	if (input_initialized && input == active_input) {
+	if (drv->input_initialized && input == drv->active_input) {
 		return;
 	}
 	si5351c_disable_all_outputs(drv);
@@ -334,8 +328,8 @@ void si5351c_change_input(si5351c_driver_t* const drv, si5351c_input_t input)
 	}
 #endif
 	si5351c_configure_pll_multisynth(drv, input);
-	active_input = input;
-	input_initialized = true;
+	drv->active_input = input;
+	drv->input_initialized = true;
 	si5351c_reset_plls(drv, SI5351C_PLL_MASK_BOTH);
 }
 
@@ -353,11 +347,11 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	drv->clk[clkout_id].output_enable = enable;
-	drv->clk[clkout_id].power_down = !enable;
+	drv->clk[drv->clkout_id].output_enable = enable;
+	drv->clk[drv->clkout_id].power_down = !enable;
 
 	/* Configure clock to 10MHz */
-	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
+	si5351c_configure_multisynth(drv, drv->clkout_id, 80 * 128 - 512, 0, 1, 0);
 
 	si5351c_configure_clock_control(drv);
 	si5351c_enable_clock_outputs(drv);
@@ -373,18 +367,18 @@ void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
 #endif
 #ifdef IS_NOT_H1_R9
 	if (IS_NOT_H1_R9) {
-		drv->clk[mcu_clkin_id].output_enable = enable;
-		drv->clk[mcu_clkin_id].power_down = !enable;
+		drv->clk[drv->mcu_clkin_id].output_enable = enable;
+		drv->clk[drv->mcu_clkin_id].power_down = !enable;
 
 		/* Configure clock to 40MHz */
-		if (mcu_clkin_id >= 6) {
+		if (drv->mcu_clkin_id >= 6) {
 			// MCU_CLKIN on CLK6 or CLK7, integer only MS.
-			si5351c_configure_multisynth(drv, mcu_clkin_id, 20, 0, 0, 0);
+			si5351c_configure_multisynth(drv, drv->mcu_clkin_id, 20, 0, 0, 0);
 		} else {
 			// MCU_CLKIN on CLK0 to CLK5, fractional-capable MS.
 			si5351c_configure_multisynth(
 				drv,
-				mcu_clkin_id,
+				drv->mcu_clkin_id,
 				20 * 128 - 512,
 				0,
 				1,
@@ -509,7 +503,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	};
 	/* CLK3: CLKOUT */
 	drv->clk[3] = clkout;
-	clkout_id = 3;
+	drv->clkout_id = 3;
 	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
 	drv->clk[4] = (si5351c_clk_t){
 		.output_enable = true,
@@ -531,7 +525,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	drv->clk[6] = powered_down;
 	/* CLK7: LPC43xx */
 	drv->clk[7] = mcu_clkin;
-	mcu_clkin_id = 7;
+	drv->mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
@@ -553,8 +547,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		/* CLK2: CLKOUT/LPC4320 */
 		drv->clk[2] = clkout;
-		clkout_id = 2;
-		mcu_clkin_id = 2;
+		drv->clkout_id = 2;
+		drv->mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
 		drv->clk[3] = powered_down;
 		drv->clk[4] = powered_down;
@@ -584,7 +578,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		/* CLK3: CLKOUT */
 		clkout.pll = SI5351C_PLL_B;
 		drv->clk[3] = clkout;
-		clkout_id = 3;
+		drv->clkout_id = 3;
 		/* CLK4: XCVR_CLK */
 		drv->clk[4] = (si5351c_clk_t){
 			.output_enable = true,
@@ -614,7 +608,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		} else {
 			/* CLK2: MCU_CLK */
 			drv->clk[2] = mcu_clkin;
-			mcu_clkin_id = 2;
+			drv->mcu_clkin_id = 2;
 		}
 	}
 #endif

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,8 +51,6 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
-si5351c_clk_t clk[8];
-
 uint8_t clkout_id;
 uint8_t mcu_clkin_id;
 
@@ -267,12 +265,12 @@ void si5351c_configure_multisynth(
 void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 {
 	for (int i = 0; i < 8; i++) {
-		set_CLK_PDN(drv, i, clk[i].power_down);
-		set_MS_INT(drv, i, clk[i].mode);
-		set_MS_SRC(drv, i, clk[i].pll);
-		set_CLK_SRC(drv, i, clk[i].source);
-		set_CLK_IDRV(drv, i, clk[i].drive);
-		set_CLK_INV(drv, i, clk[i].invert);
+		set_CLK_PDN(drv, i, drv->clk[i].power_down);
+		set_MS_INT(drv, i, drv->clk[i].mode);
+		set_MS_SRC(drv, i, drv->clk[i].pll);
+		set_CLK_SRC(drv, i, drv->clk[i].source);
+		set_CLK_IDRV(drv, i, drv->clk[i].drive);
+		set_CLK_INV(drv, i, drv->clk[i].invert);
 	}
 
 	si5351c_regs_commit(drv);
@@ -284,15 +282,15 @@ void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 		set_CLK_OEB(
 			drv,
 			i,
-			clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
-					       SI5351C_OUTPUT_DISABLE);
+			drv->clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
+						    SI5351C_OUTPUT_DISABLE);
 	}
 	si5351c_regs_commit(drv);
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (clk[clkout_id].output_enable) {
+		if (drv->clk[clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -355,8 +353,8 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clk[clkout_id].output_enable = enable;
-	clk[clkout_id].power_down = !enable;
+	drv->clk[clkout_id].output_enable = enable;
+	drv->clk[clkout_id].power_down = !enable;
 
 	/* Configure clock to 10MHz */
 	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
@@ -375,8 +373,8 @@ void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
 #endif
 #ifdef IS_NOT_H1_R9
 	if (IS_NOT_H1_R9) {
-		clk[mcu_clkin_id].output_enable = enable;
-		clk[mcu_clkin_id].power_down = !enable;
+		drv->clk[mcu_clkin_id].output_enable = enable;
+		drv->clk[mcu_clkin_id].power_down = !enable;
 
 		/* Configure clock to 40MHz */
 		if (mcu_clkin_id >= 6) {
@@ -485,7 +483,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	};
 
 	/* CLK0: MAX5864/CPLD */
-	clk[0] = (si5351c_clk_t){
+	drv->clk[0] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_FRAC,
 		.pll = SI5351C_PLL_A,
@@ -493,7 +491,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_8MA,
 	};
 	/* CLK1: CPLD */
-	clk[1] = (si5351c_clk_t){
+	drv->clk[1] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -502,7 +500,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.invert = true,
 	};
 	/* CLK2: SGPIO */
-	clk[2] = (si5351c_clk_t){
+	drv->clk[2] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -510,10 +508,10 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_2MA,
 	};
 	/* CLK3: CLKOUT */
-	clk[3] = clkout;
+	drv->clk[3] = clkout;
 	clkout_id = 3;
 	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
-	clk[4] = (si5351c_clk_t){
+	drv->clk[4] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -522,7 +520,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.invert = true,
 	};
 	/* CLK5: MAX2837 (MAX2871 on rad1o) */
-	clk[5] = (si5351c_clk_t){
+	drv->clk[5] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -530,15 +528,15 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_4MA,
 	};
 	/* CLK6: none */
-	clk[6] = powered_down;
+	drv->clk[6] = powered_down;
 	/* CLK7: LPC43xx */
-	clk[7] = mcu_clkin;
+	drv->clk[7] = mcu_clkin;
 	mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
-		clk[0] = (si5351c_clk_t){
+		drv->clk[0] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_A,
@@ -546,7 +544,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_6MA,
 		};
 		/* CLK1: RFFC5072/MAX2839 */
-		clk[1] = (si5351c_clk_t){
+		drv->clk[1] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -554,21 +552,21 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_4MA,
 		};
 		/* CLK2: CLKOUT/LPC4320 */
-		clk[2] = clkout;
+		drv->clk[2] = clkout;
 		clkout_id = 2;
 		mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
-		clk[3] = powered_down;
-		clk[4] = powered_down;
-		clk[5] = powered_down;
-		clk[6] = powered_down;
-		clk[7] = powered_down;
+		drv->clk[3] = powered_down;
+		drv->clk[4] = powered_down;
+		drv->clk[5] = powered_down;
+		drv->clk[6] = powered_down;
+		drv->clk[7] = powered_down;
 	}
 #endif
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		/* CLK0: AFE_CLK */
-		clk[0] = (si5351c_clk_t){
+		drv->clk[0] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -576,7 +574,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_4MA,
 		};
 		/* CLK1: SCT_CLK and FPGA_CLK */
-		clk[1] = (si5351c_clk_t){
+		drv->clk[1] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -585,10 +583,10 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		/* CLK3: CLKOUT */
 		clkout.pll = SI5351C_PLL_B;
-		clk[3] = clkout;
+		drv->clk[3] = clkout;
 		clkout_id = 3;
 		/* CLK4: XCVR_CLK */
-		clk[4] = (si5351c_clk_t){
+		drv->clk[4] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_B,
@@ -597,7 +595,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.invert = true,
 		};
 		/* CLK5: MIX_CLK */
-		clk[5] = (si5351c_clk_t){
+		drv->clk[5] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_B,
@@ -606,7 +604,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
 			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			clk[2] = (si5351c_clk_t){
+			drv->clk[2] = (si5351c_clk_t){
 				.output_enable = true,
 				.mode = SI5351C_MODE_FRAC,
 				.pll = SI5351C_PLL_A,
@@ -615,7 +613,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			};
 		} else {
 			/* CLK2: MCU_CLK */
-			clk[2] = mcu_clkin;
+			drv->clk[2] = mcu_clkin;
 			mcu_clkin_id = 2;
 		}
 	}

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -54,6 +54,7 @@ si5351c_driver_t si5351c = {
 si5351c_clk_t clk[8];
 
 uint8_t clkout_id;
+uint8_t mcu_clkin_id;
 
 static bool input_initialized = false;
 static si5351c_input_t active_input;
@@ -364,6 +365,40 @@ void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 	si5351c_enable_clock_outputs(drv);
 }
 
+void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
+{
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		/* MCU clock is shared with CLKOUT. */
+		si5351c_clkout_enable(drv, enable);
+	}
+#endif
+#ifdef IS_NOT_H1_R9
+	if (IS_NOT_H1_R9) {
+		clk[mcu_clkin_id].output_enable = enable;
+		clk[mcu_clkin_id].power_down = !enable;
+
+		/* Configure clock to 40MHz */
+		if (mcu_clkin_id >= 6) {
+			// MCU_CLKIN on CLK6 or CLK7, integer only MS.
+			si5351c_configure_multisynth(drv, mcu_clkin_id, 20, 0, 0, 0);
+		} else {
+			// MCU_CLKIN on CLK0 to CLK5, fractional-capable MS.
+			si5351c_configure_multisynth(
+				drv,
+				mcu_clkin_id,
+				20 * 128 - 512,
+				0,
+				1,
+				0);
+		}
+
+		si5351c_configure_clock_control(drv);
+		si5351c_enable_clock_outputs(drv);
+	}
+#endif
+}
+
 void si5351c_init(si5351c_driver_t* const drv)
 {
 	/* Read revision ID */
@@ -434,6 +469,15 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_8MA,
 	};
 
+	si5351c_clk_t mcu_clkin = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_2MA,
+	};
+
 	si5351c_clk_t powered_down = {
 		.output_enable = false,
 		.power_down = true,
@@ -488,7 +532,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 	/* CLK6: none */
 	clk[6] = powered_down;
 	/* CLK7: LPC43xx */
-	clk[7] = powered_down;
+	clk[7] = mcu_clkin;
+	mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
@@ -511,6 +556,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		/* CLK2: CLKOUT/LPC4320 */
 		clk[2] = clkout;
 		clkout_id = 2;
+		mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
 		clk[3] = powered_down;
 		clk[4] = powered_down;
@@ -569,7 +615,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 			};
 		} else {
 			/* CLK2: MCU_CLK */
-			clk[2] = powered_down;
+			clk[2] = mcu_clkin;
+			mcu_clkin_id = 2;
 		}
 	}
 #endif

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -583,6 +583,11 @@ void si5351c_init(si5351c_driver_t* const drv)
 		selftest.report.pass = false;
 	}
 
+	/* Wait for on-chip initialization to complete. */
+	while (get_SYS_INIT(drv)) {
+		si5351c_read_single(drv, SYS_INIT);
+	}
+
 	/* Cache all current register values. */
 	uint8_t data_tx[] = {0};
 	i2c_bus_transfer(

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -543,9 +543,9 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 	}
 }
 
-void si5351c_clkout_enable(si5351c_driver_t* const drv, uint8_t enable)
+void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clkout_enabled = (enable > 0);
+	clkout_enabled = enable;
 
 	uint8_t clkout = 3;
 

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,10 +51,12 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
+si5351c_clk_t clk[8];
+
+uint8_t clkout_id;
+
 static bool input_initialized = false;
 static si5351c_input_t active_input;
-/* External clock output default is deactivated as it creates noise */
-static bool clkout_enabled = false;
 
 /* write to single register */
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val)
@@ -263,146 +265,6 @@ void si5351c_configure_multisynth(
 
 void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 {
-	si5351c_clk_ctrl_t clkout = {
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_8MA,
-	};
-
-	si5351c_clk_ctrl_t powered_down = {
-		.power_down = true,
-		.mode = SI5351C_MODE_INT,
-	};
-
-	if (!clkout_enabled) {
-		clkout = powered_down;
-	}
-
-	si5351c_clk_ctrl_t clk[8];
-
-	/* Clock to CPU is deactivated as it is not used and creates noise */
-	/* External clock output is kept in current state */
-
-	/* CLK0: MAX5864/CPLD */
-	clk[0] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_FRAC,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_8MA,
-	};
-	/* CLK1: CPLD */
-	clk[1] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_0_4,
-		.drive = SI5351C_DRIVE_2MA,
-		.invert = true,
-	};
-	/* CLK2: SGPIO */
-	clk[2] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_0_4,
-		.drive = SI5351C_DRIVE_2MA,
-	};
-	/* CLK3: CLKOUT */
-	clk[3] = clkout;
-	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
-	clk[4] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_6MA,
-		.invert = true,
-	};
-	/* CLK5: MAX2837 (MAX2871 on rad1o) */
-	clk[5] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_4MA,
-	};
-	/* CLK6: none */
-	clk[6] = powered_down;
-	/* CLK7: LPC43xx */
-	clk[7] = powered_down;
-
-#ifdef IS_H1_R9
-	if (IS_H1_R9) {
-		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
-		clk[0] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_6MA,
-		};
-		/* CLK1: RFFC5072/MAX2839 */
-		clk[1] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		/* CLK2: CLKOUT/LPC4320 */
-		clk[2] = clkout;
-		/* Other outputs not present on Si5351A */
-		clk[3] = powered_down;
-		clk[4] = powered_down;
-		clk[5] = powered_down;
-		clk[6] = powered_down;
-		clk[7] = powered_down;
-	}
-#endif
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		/* CLK0: AFE_CLK */
-		clk[0] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		/* CLK1: SCT_CLK and FPGA_CLK */
-		clk[1] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_2MA,
-		};
-		/* CLK3: CLKOUT */
-		clkout.pll = SI5351C_PLL_B;
-		clk[3] = clkout;
-		/* CLK4: XCVR_CLK */
-		clk[4] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_B,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-			.invert = true,
-		};
-		/* CLK5: MIX_CLK */
-		clk[5] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_B,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
-			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			clk[2] = (si5351c_clk_ctrl_t){
-				.mode = SI5351C_MODE_FRAC,
-				.pll = SI5351C_PLL_A,
-				.source = SI5351C_SRC_MULTISYNTH_SELF,
-				.drive = SI5351C_DRIVE_2MA,
-			};
-		} else {
-			/* CLK2: MCU_CLK */
-			clk[2] = powered_down;
-		}
-	}
-#endif
-
 	for (int i = 0; i < 8; i++) {
 		set_CLK_PDN(drv, i, clk[i].power_down);
 		set_MS_INT(drv, i, clk[i].mode);
@@ -417,72 +279,19 @@ void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 
 void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 {
-	/* Enable CLK outputs 0, 1, 2, 4, 5 only. */
-	/* Praline: enable 0, 1, 4, 5 only. */
-	/* 7: Clock to CPU is deactivated as it is not used and creates noise */
-	/* 3: External clock output is deactivated by default */
-
-	uint8_t clkout = 3;
-
-	bool enable[8];
-
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		enable[0] = true;
-		enable[1] = true;
-		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
-			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			enable[2] = true;
-		} else {
-			enable[2] = false;
-		}
-		enable[3] = false;
-		enable[4] = true;
-		enable[5] = true;
-		enable[6] = false;
-		enable[7] = false;
-	}
-#endif
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		enable[0] = true;
-		enable[1] = true;
-		enable[2] = true;
-		enable[3] = false;
-		enable[4] = true;
-		enable[5] = true;
-		enable[6] = false;
-		enable[7] = false;
-
-		/* HackRF One r9 has only three clock generator outputs. */
-	#ifdef IS_H1_R9
-		if (IS_H1_R9) {
-			clkout = 2;
-			enable[0] = true;
-			enable[1] = true;
-			enable[3] = false;
-			enable[4] = false;
-			enable[5] = false;
-			enable[6] = false;
-			enable[7] = false;
-		}
-	#endif
-	}
-#endif
-	enable[clkout] = clkout_enabled;
-
 	for (int i = 0; i < 8; i++) {
 		set_CLK_OEB(
 			drv,
 			i,
-			enable[i] ? SI5351C_OUTPUT_ENABLE : SI5351C_OUTPUT_DISABLE);
+			clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
+					       SI5351C_OUTPUT_DISABLE);
 	}
 	si5351c_regs_commit(drv);
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (clkout_enabled) {
+		if (clk[clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -545,16 +354,11 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clkout_enabled = enable;
+	clk[clkout_id].output_enable = enable;
+	clk[clkout_id].power_down = !enable;
 
-	uint8_t clkout = 3;
-
-	/* HackRF One r9 has only three clock generator outputs. */
-	if (detected_platform() == BOARD_ID_HACKRF1_R9) {
-		clkout = 2;
-	}
 	/* Configure clock to 10MHz */
-	si5351c_configure_multisynth(drv, clkout, 80 * 128 - 512, 0, 1, 0);
+	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
 
 	si5351c_configure_clock_control(drv);
 	si5351c_enable_clock_outputs(drv);
@@ -618,6 +422,155 @@ void si5351c_init(si5351c_driver_t* const drv)
 		scu_pinmux(scu->H1R9_MCU_CLK_EN, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 		gpio_clear(gpio->h1r9_mcu_clk_en);
 		gpio_output(gpio->h1r9_mcu_clk_en);
+	}
+#endif
+
+	si5351c_clk_t clkout = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_8MA,
+	};
+
+	si5351c_clk_t powered_down = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+	};
+
+	/* CLK0: MAX5864/CPLD */
+	clk[0] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_FRAC,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_8MA,
+	};
+	/* CLK1: CPLD */
+	clk[1] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_0_4,
+		.drive = SI5351C_DRIVE_2MA,
+		.invert = true,
+	};
+	/* CLK2: SGPIO */
+	clk[2] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_0_4,
+		.drive = SI5351C_DRIVE_2MA,
+	};
+	/* CLK3: CLKOUT */
+	clk[3] = clkout;
+	clkout_id = 3;
+	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
+	clk[4] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_6MA,
+		.invert = true,
+	};
+	/* CLK5: MAX2837 (MAX2871 on rad1o) */
+	clk[5] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_4MA,
+	};
+	/* CLK6: none */
+	clk[6] = powered_down;
+	/* CLK7: LPC43xx */
+	clk[7] = powered_down;
+
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
+		clk[0] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_6MA,
+		};
+		/* CLK1: RFFC5072/MAX2839 */
+		clk[1] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		/* CLK2: CLKOUT/LPC4320 */
+		clk[2] = clkout;
+		clkout_id = 2;
+		/* Other outputs not present on Si5351A */
+		clk[3] = powered_down;
+		clk[4] = powered_down;
+		clk[5] = powered_down;
+		clk[6] = powered_down;
+		clk[7] = powered_down;
+	}
+#endif
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		/* CLK0: AFE_CLK */
+		clk[0] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		/* CLK1: SCT_CLK and FPGA_CLK */
+		clk[1] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_2MA,
+		};
+		/* CLK3: CLKOUT */
+		clkout.pll = SI5351C_PLL_B;
+		clk[3] = clkout;
+		clkout_id = 3;
+		/* CLK4: XCVR_CLK */
+		clk[4] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_B,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+			.invert = true,
+		};
+		/* CLK5: MIX_CLK */
+		clk[5] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_B,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
+			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
+			clk[2] = (si5351c_clk_t){
+				.output_enable = true,
+				.mode = SI5351C_MODE_FRAC,
+				.pll = SI5351C_PLL_A,
+				.source = SI5351C_SRC_MULTISYNTH_SELF,
+				.drive = SI5351C_DRIVE_2MA,
+			};
+		} else {
+			/* CLK2: MCU_CLK */
+			clk[2] = powered_down;
+		}
 	}
 #endif
 }

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -135,6 +135,7 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv);
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val);
 uint8_t si5351c_read_single(si5351c_driver_t* const drv, uint8_t reg);
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable);
+void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable);
 void si5351c_init(si5351c_driver_t* const drv);
 void si5351c_set_phase(
 	si5351c_driver_t* const drv,

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -103,6 +103,10 @@ typedef struct {
 	i2c_bus_t* const bus;
 	uint8_t i2c_address;
 	si5351c_clk_t clk[8];
+	uint8_t clkout_id;
+	uint8_t mcu_clkin_id;
+	bool input_initialized;
+	si5351c_input_t active_input;
 	uint8_t regs[SI5351C_CACHED_REGS];
 	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
 } si5351c_driver_t;

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -133,7 +133,7 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv);
 
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val);
 uint8_t si5351c_read_single(si5351c_driver_t* const drv, uint8_t reg);
-void si5351c_clkout_enable(si5351c_driver_t* const drv, uint8_t enable);
+void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable);
 void si5351c_init(si5351c_driver_t* const drv);
 void si5351c_set_phase(
 	si5351c_driver_t* const drv,

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -90,13 +90,6 @@ typedef enum {
 } si5351c_input_t;
 
 typedef struct {
-	i2c_bus_t* const bus;
-	uint8_t i2c_address;
-	uint8_t regs[SI5351C_CACHED_REGS];
-	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
-} si5351c_driver_t;
-
-typedef struct {
 	bool output_enable;
 	bool power_down;
 	si5351c_mode_t mode;
@@ -105,6 +98,14 @@ typedef struct {
 	si5351c_drive_t drive;
 	bool invert;
 } si5351c_clk_t;
+
+typedef struct {
+	i2c_bus_t* const bus;
+	uint8_t i2c_address;
+	si5351c_clk_t clk[8];
+	uint8_t regs[SI5351C_CACHED_REGS];
+	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
+} si5351c_driver_t;
 
 void si5351c_disable_all_outputs(si5351c_driver_t* const drv);
 void si5351c_disable_oeb_pin_control(si5351c_driver_t* const drv);

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -97,13 +97,14 @@ typedef struct {
 } si5351c_driver_t;
 
 typedef struct {
+	bool output_enable;
 	bool power_down;
 	si5351c_mode_t mode;
 	si5351c_pll_t pll;
 	si5351c_src_t source;
 	si5351c_drive_t drive;
 	bool invert;
-} si5351c_clk_ctrl_t;
+} si5351c_clk_t;
 
 void si5351c_disable_all_outputs(si5351c_driver_t* const drv);
 void si5351c_disable_oeb_pin_control(si5351c_driver_t* const drv);

--- a/firmware/hackrf_usb/usb_api_register.c
+++ b/firmware/hackrf_usb/usb_api_register.c
@@ -211,7 +211,7 @@ usb_request_status_t usb_vendor_request_set_clkout_enable(
 	const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		si5351c_clkout_enable(&si5351c, endpoint->setup.value);
+		si5351c_clkout_enable(&si5351c, endpoint->setup.value > 0);
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;


### PR DESCRIPTION
Further work on the Si5351 driver:

- Wait for the `SYS_INIT` bit to clear in the status register before proceeding with setup.
- Make more use of the `clk` array to clarify code.
- Add control of `MCU_CLKIN` output.