### PR TITLE
Move `cpld_jtag_sram_load` into `cpld_jtag.c`

### DIFF
--- a/firmware/common/cpld_jtag.c
+++ b/firmware/common/cpld_jtag.c
@@ -21,6 +21,7 @@
 
 #include "cpld_jtag.h"
 
+#include "cpld_xc2c.h"
 #include "platform_detect.h"
 #ifdef IS_NOT_PRALINE
 	#include <stdint.h>
@@ -137,5 +138,17 @@ unsigned char cpld_jtag_get_next_byte(void)
 	unsigned char byte = xsvf_buffer[xsvf_pos];
 	xsvf_pos++;
 	return byte;
+}
+
+bool cpld_jtag_sram_load(jtag_t* const jtag)
+{
+	cpld_jtag_take(jtag);
+	cpld_xc2c64a_jtag_sram_write(jtag, &cpld_hackrf_program_sram);
+	const bool success = cpld_xc2c64a_jtag_sram_verify(
+		jtag,
+		&cpld_hackrf_program_sram,
+		&cpld_hackrf_verify);
+	cpld_jtag_release(jtag);
+	return success;
 }
 #endif

--- a/firmware/common/cpld_jtag.h
+++ b/firmware/common/cpld_jtag.h
@@ -58,6 +58,7 @@ int cpld_jtag_program(
 	unsigned char* const buffer,
 	refill_buffer_cb refill);
 unsigned char cpld_jtag_get_next_byte(void);
+bool cpld_jtag_sram_load(jtag_t* const jtag);
 
 /* Driver instance. */
 extern jtag_gpio_t jtag_gpio_cpld;

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -69,7 +69,6 @@
 #endif
 #ifdef IS_NOT_PRALINE
 	#include <cpld_jtag.h>
-	#include <cpld_xc2c.h>
 #endif
 
 #include "usb_api_adc.h"
@@ -260,20 +259,6 @@ void usb_set_descriptor_by_serial_number(void)
 		usb_descriptor_string_serial_number[1] = USB_DESCRIPTOR_TYPE_STRING;
 	}
 }
-
-#ifdef IS_NOT_PRALINE
-static bool cpld_jtag_sram_load(jtag_t* const jtag)
-{
-	cpld_jtag_take(jtag);
-	cpld_xc2c64a_jtag_sram_write(jtag, &cpld_hackrf_program_sram);
-	const bool success = cpld_xc2c64a_jtag_sram_verify(
-		jtag,
-		&cpld_hackrf_program_sram,
-		&cpld_hackrf_verify);
-	cpld_jtag_release(jtag);
-	return success;
-}
-#endif
 
 static void m0_rom_to_ram(void)
 {


### PR DESCRIPTION
This doesn't need to be in `hackrf_usb.c`; move it so that we can use it elsewhere.