### PR TITLE
Reduce dependencies of `pins.c`

### DIFF
--- a/firmware/common/cpld_jtag.c
+++ b/firmware/common/cpld_jtag.c
@@ -22,6 +22,7 @@
 #include "cpld_jtag.h"
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #ifdef IS_NOT_PRALINE
 	#include <stdbool.h>
 	#include <stdint.h>
@@ -41,6 +42,28 @@ jtag_gpio_t jtag_gpio_cpld = {};
 jtag_t jtag_cpld = {
 	.gpio = &jtag_gpio_cpld,
 };
+
+void cpld_jtag_pin_setup(void)
+{
+	const platform_gpio_t* gpio = platform_gpio();
+
+	jtag_gpio_cpld.gpio_tck = gpio->cpld_tck;
+
+#ifdef IS_NOT_PRALINE
+	if (IS_NOT_PRALINE) {
+		jtag_gpio_cpld.gpio_tms = gpio->cpld_tms;
+		jtag_gpio_cpld.gpio_tdi = gpio->cpld_tdi;
+		jtag_gpio_cpld.gpio_tdo = gpio->cpld_tdo;
+	}
+#endif
+
+#ifdef IS_EXPANSION_COMPATIBLE
+	if (IS_EXPANSION_COMPATIBLE) {
+		jtag_gpio_cpld.gpio_pp_tms = gpio->cpld_pp_tms;
+		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
+	}
+#endif
+}
 
 void cpld_jtag_take(jtag_t* const jtag)
 {

--- a/firmware/common/cpld_jtag.h
+++ b/firmware/common/cpld_jtag.h
@@ -45,6 +45,7 @@ typedef struct {
 
 typedef void (*refill_buffer_cb)(void);
 
+void cpld_jtag_pin_setup(void);
 void cpld_jtag_take(jtag_t* const jtag);
 void cpld_jtag_release(jtag_t* const jtag);
 

--- a/firmware/common/ice40_spi.c
+++ b/firmware/common/ice40_spi.c
@@ -26,6 +26,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "delay.h"
+#include "platform_gpio.h"
 #include "platform_scu.h"
 
 /* Driver instance. */
@@ -42,7 +43,14 @@ ice40_spi_driver_t ice40 = {
 
 void ice40_spi_target_init(ice40_spi_driver_t* const drv)
 {
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+
+	/* Configure drivers and driver pins */
+	ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
+	ice40.gpio_select = gpio->fpga_cfg_spi_cs;
+	ice40.gpio_creset = gpio->fpga_cfg_creset;
+	ice40.gpio_cdone = gpio->fpga_cfg_cdone;
 
 	/* Configure SSP1 Peripheral and relevant FPGA pins. */
 	scu_pinmux(scu->SSP1_CIPO, (SCU_SSP_IO | SCU_CONF_FUNCTION5));

--- a/firmware/common/max283x.c
+++ b/firmware/common/max283x.c
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <libopencm3/lpc43xx/ssp.h>
+
 #include "fixed_point.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
@@ -88,8 +90,10 @@ void max283x_setup(max283x_driver_t* const drv)
 	const platform_gpio_t* gpio = platform_gpio();
 
 	/* MAX283x GPIO PinMux */
+	ssp_config_max283x.gpio_select = gpio->max283x_select;
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
+		ssp_config_max283x.data_bits = SSP_DATA_9BITS;
 		drv->type = MAX2831_VARIANT;
 		max2831.gpio_enable = gpio->max283x_enable;
 		max2831.gpio_rxtx = gpio->max283x_rx_enable;
@@ -101,6 +105,7 @@ void max283x_setup(max283x_driver_t* const drv)
 #endif
 #ifdef IS_NOT_PRALINE
 	if (IS_NOT_PRALINE) {
+		ssp_config_max283x.data_bits = SSP_DATA_16BITS;
 	#ifdef IS_H1_R9
 		if (IS_H1_R9) {
 			drv->type = MAX2839_VARIANT;

--- a/firmware/common/max5864.c
+++ b/firmware/common/max5864.c
@@ -27,6 +27,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "max5864_target.h"
+#include "platform_gpio.h"
 #include "spi_bus.h"
 
 /* Driver instance. */
@@ -60,6 +61,8 @@ static void max5864_init(max5864_driver_t* const drv)
 
 void max5864_setup(max5864_driver_t* const drv)
 {
+	ssp_config_max5864.gpio_select = platform_gpio()->max5864_select;
+
 	max5864_init(drv);
 }
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -24,12 +24,10 @@
 #include "pins.h"
 
 #include <libopencm3/lpc43xx/scu.h>
-#include <libopencm3/lpc43xx/ssp.h>
 
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "max283x.h"
 #include "max5864.h"
 #include "mixer.h"
 #include "platform_detect.h"
@@ -266,18 +264,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_max283x.gpio_select = gpio->max283x_select;
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		ssp_config_max283x.data_bits = SSP_DATA_16BITS;
-	}
-#endif
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		ssp_config_max283x.data_bits = SSP_DATA_9BITS; // send 2 words
-	}
-#endif
-
 	ssp_config_max5864.gpio_select = gpio->max5864_select;
 
 	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -28,7 +28,6 @@
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "mixer.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
 #include "platform_scu.h"
@@ -280,8 +279,6 @@ void pins_setup(void)
 		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
 	}
 #endif
-
-	mixer_bus_setup(&mixer);
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -33,7 +33,6 @@
 #include "power.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
-	#include "ice40_spi.h"
 #endif
 
 void pins_shutdown(void)
@@ -249,16 +248,6 @@ void pins_setup(void)
 #ifdef IS_FOUR_LEDS
 	if (IS_FOUR_LEDS) {
 		gpio_output(gpio->led[3]);
-	}
-#endif
-
-	/* Configure drivers and driver pins */
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
-		ice40.gpio_select = gpio->fpga_cfg_spi_cs;
-		ice40.gpio_creset = gpio->fpga_cfg_creset;
-		ice40.gpio_cdone = gpio->fpga_cfg_cdone;
 	}
 #endif
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -35,7 +35,6 @@
 #include "power.h"
 #include "rf_path.h"
 #include "sgpio.h"
-#include "w25q80bv.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -263,10 +262,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
-	spi_flash.gpio_hold = gpio->w25q80bv_hold;
-	spi_flash.gpio_wp = gpio->w25q80bv_wp;
-
 	sgpio_config.gpio_q_invert = gpio->q_invert;
 
 #ifdef IS_NOT_PRALINE

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -25,7 +25,6 @@
 
 #include <libopencm3/lpc43xx/scu.h>
 
-#include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
 #include "platform_detect.h"
@@ -260,23 +259,6 @@ void pins_setup(void)
 		ice40.gpio_select = gpio->fpga_cfg_spi_cs;
 		ice40.gpio_creset = gpio->fpga_cfg_creset;
 		ice40.gpio_cdone = gpio->fpga_cfg_cdone;
-	}
-#endif
-
-	jtag_gpio_cpld.gpio_tck = gpio->cpld_tck;
-
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		jtag_gpio_cpld.gpio_tms = gpio->cpld_tms;
-		jtag_gpio_cpld.gpio_tdi = gpio->cpld_tdi;
-		jtag_gpio_cpld.gpio_tdo = gpio->cpld_tdo;
-	}
-#endif
-
-#ifdef IS_EXPANSION_COMPATIBLE
-	if (IS_EXPANSION_COMPATIBLE) {
-		jtag_gpio_cpld.gpio_pp_tms = gpio->cpld_pp_tms;
-		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
 	}
 #endif
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -34,7 +34,6 @@
 #include "platform_scu.h"
 #include "power.h"
 #include "rf_path.h"
-#include "sgpio.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -228,7 +227,6 @@ void pins_shutdown(void)
 		rf_path_pin_shutdown();
 	}
 #endif
-	sgpio_pin_shutdown(&sgpio_config);
 
 	/* enable input on SCL and SDA pins */
 	SCU_SFSI2C0 = SCU_I2C0_NOMINAL;
@@ -262,14 +260,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	sgpio_config.gpio_q_invert = gpio->q_invert;
-
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		sgpio_config.gpio_trigger_enable = gpio->trigger_enable;
-	}
-#endif
-
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
@@ -297,12 +287,6 @@ void pins_setup(void)
 #endif
 
 	mixer_bus_setup(&mixer);
-
-#ifdef IS_H1_R9
-	if (IS_H1_R9) {
-		sgpio_config.gpio_trigger_enable = gpio->h1r9_trigger_enable;
-	}
-#endif
 
 	// initialize rf_path struct and assign gpio's
 #ifdef IS_HACKRF_ONE
@@ -375,6 +359,4 @@ void pins_setup(void)
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);
-
-	sgpio_configure_pin_functions(&sgpio_config);
 }

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -33,7 +33,6 @@
 #include "platform_gpio.h"
 #include "platform_scu.h"
 #include "power.h"
-#include "rf_path.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -204,7 +203,6 @@ void pins_shutdown(void)
 
 		p2_ctrl_set(P2_SIGNAL_CLK3);
 		p1_ctrl_set(P1_SIGNAL_CLKIN);
-		narrowband_filter_set(0);
 		clkin_ctrl_set(CLKIN_SIGNAL_P1);
 
 		gpio_output(gpio->p2_ctrl0);
@@ -214,7 +212,6 @@ void pins_shutdown(void)
 		gpio_output(gpio->p1_ctrl2);
 		gpio_output(gpio->clkin_ctrl);
 		gpio_output(gpio->pps_out);
-		gpio_output(gpio->aa_en);
 		gpio_input(gpio->trigger_in);
 		gpio_input(gpio->trigger_out);
 		gpio_clear(gpio->fpga_cfg_spi_cs);
@@ -223,8 +220,6 @@ void pins_shutdown(void)
 		gpio_output(gpio->fpga_cfg_creset);
 		gpio_input(gpio->fpga_cfg_cdone);
 		gpio_input(gpio->max5864_select);
-
-		rf_path_pin_shutdown();
 	}
 #endif
 
@@ -287,75 +282,6 @@ void pins_setup(void)
 #endif
 
 	mixer_bus_setup(&mixer);
-
-	// initialize rf_path struct and assign gpio's
-#ifdef IS_HACKRF_ONE
-	if (IS_HACKRF_ONE) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_hp = gpio->hp,
-			.gpio_lp = gpio->lp,
-			.gpio_tx_mix_bp = gpio->tx_mix_bp,
-			.gpio_no_mix_bypass = gpio->no_mix_bypass,
-			.gpio_rx_mix_bp = gpio->rx_mix_bp,
-			.gpio_tx_amp = gpio->tx_amp,
-			.gpio_tx = gpio->tx,
-			.gpio_mix_bypass = gpio->mix_bypass,
-			.gpio_rx = gpio->rx,
-			.gpio_no_tx_amp_pwr = gpio->no_tx_amp_pwr,
-			.gpio_amp_bypass = gpio->amp_bypass,
-			.gpio_rx_amp = gpio->rx_amp,
-			.gpio_no_rx_amp_pwr = gpio->no_rx_amp_pwr,
-		};
-	#ifdef IS_H1_R9
-		if (IS_H1_R9) {
-			rf_path.gpio_rx = gpio->h1r9_rx;
-			rf_path.gpio_h1r9_no_ant_pwr = gpio->h1r9_no_ant_pwr;
-		}
-	#endif
-	}
-#endif
-
-#ifdef IS_RAD1O
-	if (IS_RAD1O) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_tx_rx_n = gpio->tx_rx_n,
-			.gpio_tx_rx = gpio->tx_rx,
-			.gpio_by_mix = gpio->by_mix,
-			.gpio_by_mix_n = gpio->by_mix_n,
-			.gpio_by_amp = gpio->by_amp,
-			.gpio_by_amp_n = gpio->by_amp_n,
-			.gpio_mixer_en = gpio->mixer_en,
-			.gpio_low_high_filt = gpio->low_high_filt,
-			.gpio_low_high_filt_n = gpio->low_high_filt_n,
-			.gpio_tx_amp = gpio->tx_amp,
-			.gpio_rx_lna = gpio->rx_lna,
-		};
-	}
-#endif
-
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_tx_en = gpio->tx_en,
-			.gpio_mix_en_n = gpio->mix_en_n,
-			.gpio_lpf_en = gpio->lpf_en,
-			.gpio_rf_amp_en = gpio->rf_amp_en,
-			.gpio_ant_bias_en_n = gpio->ant_bias_en_n,
-		};
-		if ((detected_revision() == BOARD_REV_PRALINE_R1_0) ||
-		    (detected_revision() == BOARD_REV_GSG_PRALINE_R1_0)) {
-			rf_path.gpio_mix_en_n = gpio->mix_en_n_r1_0;
-		}
-		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
-		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-	}
-#endif
-
-	rf_path_pin_setup(&rf_path);
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -28,7 +28,6 @@
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "max5864.h"
 #include "mixer.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
@@ -264,8 +263,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_max5864.gpio_select = gpio->max5864_select;
-
 	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
 	spi_flash.gpio_hold = gpio->w25q80bv_hold;
 	spi_flash.gpio_wp = gpio->w25q80bv_wp;

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -30,8 +30,6 @@
 #ifdef IS_NOT_JAWBREAKER
 	#include <libopencm3/lpc43xx/scu.h>
 	#include "platform_scu.h"
-#endif
-#ifdef IS_PRALINE
 	#include "platform_gpio.h"
 #endif
 
@@ -344,6 +342,10 @@ void rf_path_pin_shutdown(void)
 
 		/* Configure RF power supply (VAA) switch */
 		scu_pinmux(scu->NO_VAA_ENABLE, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		/* Disable narrowband filter. */
+		narrowband_filter_set(0);
+		gpio_output(platform_gpio()->aa_en);
 	}
 #endif
 }
@@ -353,7 +355,75 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 #ifdef IS_JAWBREAKER
 	(void) rf_path;
 #else
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+#endif
+
+	// initialize rf_path struct and assign gpio's
+#ifdef IS_HACKRF_ONE
+	if (IS_HACKRF_ONE) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_hp = gpio->hp,
+			.gpio_lp = gpio->lp,
+			.gpio_tx_mix_bp = gpio->tx_mix_bp,
+			.gpio_no_mix_bypass = gpio->no_mix_bypass,
+			.gpio_rx_mix_bp = gpio->rx_mix_bp,
+			.gpio_tx_amp = gpio->tx_amp,
+			.gpio_tx = gpio->tx,
+			.gpio_mix_bypass = gpio->mix_bypass,
+			.gpio_rx = gpio->rx,
+			.gpio_no_tx_amp_pwr = gpio->no_tx_amp_pwr,
+			.gpio_amp_bypass = gpio->amp_bypass,
+			.gpio_rx_amp = gpio->rx_amp,
+			.gpio_no_rx_amp_pwr = gpio->no_rx_amp_pwr,
+		};
+	#ifdef IS_H1_R9
+		if (IS_H1_R9) {
+			rf_path->gpio_rx = gpio->h1r9_rx;
+			rf_path->gpio_h1r9_no_ant_pwr = gpio->h1r9_no_ant_pwr;
+		}
+	#endif
+	}
+#endif
+
+#ifdef IS_RAD1O
+	if (IS_RAD1O) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_tx_rx_n = gpio->tx_rx_n,
+			.gpio_tx_rx = gpio->tx_rx,
+			.gpio_by_mix = gpio->by_mix,
+			.gpio_by_mix_n = gpio->by_mix_n,
+			.gpio_by_amp = gpio->by_amp,
+			.gpio_by_amp_n = gpio->by_amp_n,
+			.gpio_mixer_en = gpio->mixer_en,
+			.gpio_low_high_filt = gpio->low_high_filt,
+			.gpio_low_high_filt_n = gpio->low_high_filt_n,
+			.gpio_tx_amp = gpio->tx_amp,
+			.gpio_rx_lna = gpio->rx_lna,
+		};
+	}
+#endif
+
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_tx_en = gpio->tx_en,
+			.gpio_mix_en_n = gpio->mix_en_n,
+			.gpio_lpf_en = gpio->lpf_en,
+			.gpio_rf_amp_en = gpio->rf_amp_en,
+			.gpio_ant_bias_en_n = gpio->ant_bias_en_n,
+		};
+		if ((detected_revision() == BOARD_REV_PRALINE_R1_0) ||
+		    (detected_revision() == BOARD_REV_GSG_PRALINE_R1_0)) {
+			rf_path->gpio_mix_en_n = gpio->mix_en_n_r1_0;
+		}
+		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+	}
 #endif
 
 #ifdef IS_HACKRF_ONE

--- a/firmware/common/rom_iap.c
+++ b/firmware/common/rom_iap.c
@@ -23,7 +23,6 @@
 #include <stdint.h>
 
 #include "rom_iap.h"
-#include "spi_bus.h"
 #include "w25q80bv.h"
 
 #define ROM_IAP_ADDR       (0x10400100)
@@ -77,7 +76,6 @@ isp_iap_ret_code_t iap_cmd_call(iap_cmd_res_t* iap_cmd_res)
 		  Alternative way to retrieve Part Id on MCU with no IAP 
 		  Read Serial No => Read Unique ID in SPIFI (only compatible with W25Q80BV
 		*/
-		spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 		w25q80bv_setup(&spi_flash);
 
 		switch (iap_cmd_res->cmd_param.command_code) {

--- a/firmware/common/sgpio.c
+++ b/firmware/common/sgpio.c
@@ -29,6 +29,7 @@
 #include <libopencm3/lpc43xx/sgpio.h>
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #include "platform_scu.h"
 #include "sgpio.h"
 #ifdef IS_NOT_PRALINE
@@ -91,7 +92,22 @@ void sgpio_pin_shutdown(sgpio_config_t* const config)
 
 void sgpio_configure_pin_functions(sgpio_config_t* const config)
 {
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+
+	config->gpio_q_invert = gpio->q_invert;
+
+#ifdef IS_NOT_PRALINE
+	if (IS_NOT_PRALINE) {
+		config->gpio_trigger_enable = gpio->trigger_enable;
+	}
+#endif
+
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		config->gpio_trigger_enable = gpio->h1r9_trigger_enable;
+	}
+#endif
 
 	scu_pinmux(scu->PINMUX_SGPIO0, scu->PINMUX_SGPIO0_PINCFG);
 	scu_pinmux(scu->PINMUX_SGPIO1, scu->PINMUX_SGPIO1_PINCFG);

--- a/firmware/common/w25q80bv.c
+++ b/firmware/common/w25q80bv.c
@@ -35,6 +35,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #include "w25q80bv_target.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
@@ -90,6 +91,11 @@ static void w25q80bv_transfer_gather(
 void w25q80bv_setup(w25q80bv_driver_t* const drv)
 {
 	uint8_t device_id;
+	const platform_gpio_t* gpio = platform_gpio();
+
+	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
+	spi_flash.gpio_hold = gpio->w25q80bv_hold;
+	spi_flash.gpio_wp = gpio->w25q80bv_wp;
 
 	drv->page_len = 256U;
 	if (detected_platform() == BOARD_ID_PRALINE) {

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -37,6 +37,7 @@
 #include <hackrf_ui.h>
 #include <leds.h>
 #include <operacake.h>
+#include <mixer.h>
 #include <pins.h>
 #include <platform_detect.h>
 #include <power.h>
@@ -56,7 +57,6 @@
 	#include <portapack.h>
 #endif
 #ifdef IS_NOT_RAD1O
-	#include <mixer.h>
 	#include <rffc5071.h>
 #endif
 #ifdef IS_PRALINE
@@ -436,6 +436,7 @@ int main(void)
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	mixer_bus_setup(&mixer);
 	sgpio_configure_pin_functions(&sgpio_config);
 	rf_path_pin_setup(&rf_path);
 #ifdef IS_PRALINE

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -275,7 +275,6 @@ extern uint32_t _binary_fpga_bin_start;
 
 void fpga_loader_setup(void)
 {
-	spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 	w25q80bv_setup(&spi_flash);
 }
 

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -429,11 +429,13 @@ int main(void)
 	board_id_t board_id = detected_platform();
 
 	pins_shutdown();
+	sgpio_pin_shutdown(&sgpio_config);
 	if (board_id != BOARD_ID_RAD1O) {
 		clock_gen_shutdown();
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	sgpio_configure_pin_functions(&sgpio_config);
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		enable_3v3aux_power();

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -30,6 +30,7 @@
 
 #include <clock_gen.h>
 #include <clock_io.h>
+#include <cpld_jtag.h>
 #include <cpu_clock.h>
 #include <da7219.h>
 #include <delay.h>
@@ -66,9 +67,6 @@
 		#include <spi_bus.h>
 		#include <w25q80bv.h>
 	#endif
-#endif
-#ifdef IS_NOT_PRALINE
-	#include <cpld_jtag.h>
 #endif
 
 #include "usb_api_adc.h"
@@ -436,6 +434,7 @@ int main(void)
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	cpld_jtag_pin_setup();
 	mixer_bus_setup(&mixer);
 	sgpio_configure_pin_functions(&sgpio_config);
 	rf_path_pin_setup(&rf_path);

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -430,12 +430,14 @@ int main(void)
 
 	pins_shutdown();
 	sgpio_pin_shutdown(&sgpio_config);
+	rf_path_pin_shutdown();
 	if (board_id != BOARD_ID_RAD1O) {
 		clock_gen_shutdown();
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
 	sgpio_configure_pin_functions(&sgpio_config);
+	rf_path_pin_setup(&rf_path);
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		enable_3v3aux_power();

--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -30,6 +30,7 @@
 #include <firmware_info.h>
 #include <pins.h>
 #include <platform_detect.h>
+#include <rf_path.h>
 #include <rom_iap.h>
 #include <sgpio.h>
 #include <usb_queue.h>
@@ -132,6 +133,7 @@ usb_request_status_t usb_vendor_request_reset(
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		pins_shutdown();
 		sgpio_pin_shutdown(&sgpio_config);
+		rf_path_pin_shutdown();
 		clock_gen_shutdown();
 #ifdef IS_H1_R9
 		if (IS_H1_R9) {

--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -31,6 +31,7 @@
 #include <pins.h>
 #include <platform_detect.h>
 #include <rom_iap.h>
+#include <sgpio.h>
 #include <usb_queue.h>
 #include <usb_request.h>
 #include <usb_type.h>
@@ -130,6 +131,7 @@ usb_request_status_t usb_vendor_request_reset(
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		pins_shutdown();
+		sgpio_pin_shutdown(&sgpio_config);
 		clock_gen_shutdown();
 #ifdef IS_H1_R9
 		if (IS_H1_R9) {

--- a/firmware/hackrf_usb/usb_api_spiflash.c
+++ b/firmware/hackrf_usb/usb_api_spiflash.c
@@ -26,7 +26,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <spi_bus.h>
 #include <usb_queue.h>
 #include <usb_request.h>
 #include <usb_type.h>
@@ -40,7 +39,6 @@ usb_request_status_t usb_vendor_request_erase_spiflash(
 	const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 		w25q80bv_setup(&spi_flash);
 		/* only chip erase is implemented */
 		w25q80bv_chip_erase(&spi_flash);
@@ -69,7 +67,6 @@ usb_request_status_t usb_vendor_request_write_spiflash(
 				len,
 				NULL,
 				NULL);
-			spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 			w25q80bv_setup(&spi_flash);
 			return USB_REQUEST_STATUS_OK;
 		}


### PR DESCRIPTION
Moves various driver-specific code out of `pins.c` and into the `setup` and `shutdown` functions of the relevant drivers, so that it's possible to build `pins.c` without depending on all the drivers.