### PR TITLE
Move LPC43xx I2C instances and config to `i2c_lpc.{c,h}`

### DIFF
--- a/firmware/common/clock_gen.c
+++ b/firmware/common/clock_gen.c
@@ -25,6 +25,7 @@
 
 #include "hackrf_ui.h"
 #include "i2c_bus.h"
+#include "i2c_lpc.h"
 #include "platform_detect.h"
 #include "sgpio.h"
 #include "si5351c.h"
@@ -35,7 +36,7 @@
 
 void clock_gen_init(void)
 {
-	i2c_bus_start(si5351c.bus, &i2c_config_si5351c_fast_clock);
+	i2c_bus_start(si5351c.bus, &i2c_config_fast_clock);
 
 	si5351c_init(&si5351c);
 	si5351c_disable_all_outputs(&si5351c);
@@ -119,7 +120,7 @@ void clock_gen_init(void)
 
 void clock_gen_shutdown(void)
 {
-	i2c_bus_start(si5351c.bus, &i2c_config_si5351c_fast_clock);
+	i2c_bus_start(si5351c.bus, &i2c_config_fast_clock);
 	si5351c_disable_all_outputs(&si5351c);
 	si5351c_disable_oeb_pin_control(&si5351c);
 	si5351c_power_down_all_clocks(&si5351c);

--- a/firmware/common/cpu_clock.c
+++ b/firmware/common/cpu_clock.c
@@ -30,6 +30,7 @@
 
 #include "delay.h"
 #include "i2c_bus.h"
+#include "i2c_lpc.h"
 #include "si5351c.h"
 
 /*
@@ -113,7 +114,7 @@ void cpu_clock_init(void)
 
 	//FIXME disable I2C
 	/* Kick I2C0 down to 400kHz when we switch over to APB1 clock = 204MHz */
-	i2c_bus_start(si5351c.bus, &i2c_config_si5351c_fast_clock);
+	i2c_bus_start(si5351c.bus, &i2c_config_fast_clock);
 
 	/*
 	 * 12MHz clock is entering LPC XTAL1/OSC input now.

--- a/firmware/common/da7219.c
+++ b/firmware/common/da7219.c
@@ -23,6 +23,7 @@
 
 #include "da7219.h"
 #include "i2c_bus.h"
+#include "i2c_lpc.h"
 
 #define DA7219_REG_CHIP_ID1 0x81
 #define DA7219_REG_CHIP_ID2 0x82

--- a/firmware/common/i2c_bus.c
+++ b/firmware/common/i2c_bus.c
@@ -22,25 +22,6 @@
 
 #include "i2c_bus.h"
 
-#include <libopencm3/lpc43xx/memorymap.h>
-
-#include "i2c_lpc.h"
-
-/* Driver instances. */
-i2c_bus_t i2c0 = {
-	.obj = (void*) I2C0_BASE,
-	.start = i2c_lpc_start,
-	.stop = i2c_lpc_stop,
-	.transfer = i2c_lpc_transfer,
-};
-
-i2c_bus_t i2c1 = {
-	.obj = (void*) I2C1_BASE,
-	.start = i2c_lpc_start,
-	.stop = i2c_lpc_stop,
-	.transfer = i2c_lpc_transfer,
-};
-
 void i2c_bus_start(i2c_bus_t* const bus, const void* const config)
 {
 	bus->start(bus, config);

--- a/firmware/common/i2c_bus.h
+++ b/firmware/common/i2c_bus.h
@@ -47,7 +47,3 @@ void i2c_bus_transfer(
 	const size_t tx_count,
 	uint8_t* const rx,
 	const size_t rx_count);
-
-/* Driver instances. */
-extern i2c_bus_t i2c0;
-extern i2c_bus_t i2c1;

--- a/firmware/common/i2c_lpc.c
+++ b/firmware/common/i2c_lpc.c
@@ -23,6 +23,26 @@
 #include "i2c_lpc.h"
 
 #include <libopencm3/lpc43xx/i2c.h>
+#include <libopencm3/lpc43xx/memorymap.h>
+
+/* Driver instances. */
+i2c_bus_t i2c0 = {
+	.obj = (void*) I2C0_BASE,
+	.start = i2c_lpc_start,
+	.stop = i2c_lpc_stop,
+	.transfer = i2c_lpc_transfer,
+};
+
+i2c_bus_t i2c1 = {
+	.obj = (void*) I2C1_BASE,
+	.start = i2c_lpc_start,
+	.stop = i2c_lpc_stop,
+	.transfer = i2c_lpc_transfer,
+};
+
+const i2c_lpc_config_t i2c_config_fast_clock = {
+	.duty_cycle_count = 255,
+};
 
 /* FIXME return i2c0 status from each function */
 

--- a/firmware/common/i2c_lpc.h
+++ b/firmware/common/i2c_lpc.h
@@ -42,3 +42,8 @@ void i2c_lpc_transfer(
 	uint8_t* const data_rx,
 	const size_t count_rx);
 bool i2c_probe(i2c_bus_t* const bus, const uint_fast8_t device_address);
+
+/* Driver instances. */
+extern const i2c_lpc_config_t i2c_config_fast_clock;
+extern i2c_bus_t i2c0;
+extern i2c_bus_t i2c1;

--- a/firmware/common/operacake.c
+++ b/firmware/common/operacake.c
@@ -29,6 +29,7 @@
 #include "gpio.h"
 #include "gpio_lpc.h"
 #include "i2c_bus.h"
+#include "i2c_lpc.h"
 #include "operacake_sctimer.h"
 #include "platform_scu.h"
 

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -40,12 +40,6 @@
 #include "si5351c_regs.def"
 
 /* Driver instance. */
-// const i2c_lpc_config_t i2c_config_si5351c_slow_clock = {
-// 	.duty_cycle_count = 15,
-// };
-const i2c_lpc_config_t i2c_config_si5351c_fast_clock = {
-	.duty_cycle_count = 255,
-};
 si5351c_driver_t si5351c = {
 	.bus = &i2c0,
 	.i2c_address = 0x60,

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -30,7 +30,6 @@ extern "C" {
 #include <stdint.h>
 
 #include "i2c_bus.h"
-#include "i2c_lpc.h"
 
 #define SI_INTDIV(x) (x * 128 - 512)
 
@@ -141,7 +140,6 @@ void si5351c_set_phase(
 	const uint8_t offset);
 
 /* Driver Instance. */
-extern const i2c_lpc_config_t i2c_config_si5351c_fast_clock;
 extern si5351c_driver_t si5351c;
 
 #ifdef __cplusplus


### PR DESCRIPTION
It makes more sense to put `i2c0` and `i2c1` in `i2c_lpc`, since they're the I2C resources available on the LPC43xx, whereas `i2c_bus` is a generic middleware layer.

Similarly `i2c_config_fast_clock` is an LPC43xx I2C config for fast I2C (400kHz) at the usual input clock rate of 204MHz, so it doesn't belong specifically in the `si5351c` driver.