### PR TITLE
Remove sample rate callback, move radio instance to `radio.c`.

### DIFF
--- a/firmware/common/radio.c
+++ b/firmware/common/radio.c
@@ -25,6 +25,7 @@
 
 #include <libopencm3/cm3/nvic.h>
 
+#include "clock_gen.h"
 #include "clock_io.h"
 #include "fixed_point.h"
 #include "max283x.h"
@@ -40,6 +41,9 @@
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+
+/* Driver instance. */
+radio_t radio;
 
 void radio_init(radio_t* const radio)
 {
@@ -231,22 +235,19 @@ static uint32_t radio_update_sample_rate(radio_t* const radio, uint64_t* bank)
 	}
 	new_n = (n != previous_n);
 
-	if (radio->sample_rate_cb) {
-		afe_rate = rate << n;
-		afe_rate = radio->sample_rate_cb(afe_rate, false);
-		previous_rate = radio->config[RADIO_BANK_APPLIED][RADIO_SAMPLE_RATE];
-		if ((previous_n == RADIO_UNSET) || previous_rate == RADIO_UNSET) {
-			previous_afe_rate = RADIO_UNSET;
-		} else {
-			previous_afe_rate = previous_rate << previous_n;
-		}
-		new_afe_rate = (afe_rate != previous_afe_rate);
-		if (new_afe_rate) {
-			afe_rate = radio->sample_rate_cb(afe_rate, true);
-		}
+	afe_rate = rate << n;
+	afe_rate = sample_rate_set(afe_rate, false);
+	previous_rate = radio->config[RADIO_BANK_APPLIED][RADIO_SAMPLE_RATE];
+	if ((previous_n == RADIO_UNSET) || previous_rate == RADIO_UNSET) {
+		previous_afe_rate = RADIO_UNSET;
 	} else {
-		return 0;
+		previous_afe_rate = previous_rate << previous_n;
 	}
+	new_afe_rate = (afe_rate != previous_afe_rate);
+	if (new_afe_rate) {
+		afe_rate = sample_rate_set(afe_rate, true);
+	}
+
 	rate = afe_rate >> n;
 	new_rate = (rate != previous_rate);
 	if (new_rate) {

--- a/firmware/common/radio.h
+++ b/firmware/common/radio.h
@@ -225,7 +225,6 @@ typedef struct {
 	radio_config_mode_t config_mode;
 	uint64_t config[RADIO_NUM_BANKS][RADIO_NUM_REGS];
 	volatile uint32_t regs_dirty;
-	sample_rate_fn sample_rate_cb;
 	update_fn update_cb;
 } radio_t;
 
@@ -263,8 +262,5 @@ void radio_switch_opmode(radio_t* const radio, const transceiver_mode_t mode);
 
 /**
  * Driver instance.
- *
- * This needs to be configured and provided by the application
- * binary. e.g. firmware/hackrf_usb/hackrf_usb.c
  */
 extern radio_t radio;

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -96,10 +96,6 @@ extern uint32_t __m0_end__;
 extern uint32_t __ram_m0_start__;
 extern uint32_t _etext_ram, _text_ram, _etext_rom;
 
-radio_t radio = {
-	.sample_rate_cb = sample_rate_set,
-};
-
 static usb_request_handler_fn vendor_request_handler[] = {
 	NULL,
 	usb_vendor_request_set_transceiver_mode,


### PR DESCRIPTION
We no longer need this mechanism, so remove a bit of unnecessary complexity.