### PR TITLE
Add SigDigger support information to documentation

### DIFF
--- a/docs/source/software_support.rst
+++ b/docs/source/software_support.rst
@@ -43,6 +43,11 @@ Software That Has Direct Support For HackRF
 
     * `https://xakcop.com/aprs-sdr <https://xakcop.com/aprs-sdr/>`__
 
+* SigDigger (Windows/Linux/macOS)
+
+    * `https://github.com/BatchDrake/SigDigger <https://github.com/BatchDrake/SigDigger>`__
+    * Supports HackRF through SoapySDR / SoapyHackRF
+
 
 
 Software That Can Use Data From HackRF


### PR DESCRIPTION
<img width="1505" height="788" alt="image" src="https://github.com/user-attachments/assets/0c056f3d-d2a5-4949-b755-6db6c0ae885b" />

(Windows) Sigdigger & HackRF PRO working radioconda+conda install -c conda-forge hackrf=2026.01.3+Mayhem stable v2.4.0

https://github.com/batchdrake/sigdigger