### PR TITLE
Fix management of CLKOUT/MCU_CLK synth sharing on H1R9

### DIFF
--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -274,17 +274,6 @@ void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 						    SI5351C_OUTPUT_DISABLE);
 	}
 	si5351c_regs_commit(drv);
-
-#ifdef IS_H1_R9
-	if (IS_H1_R9) {
-		const platform_gpio_t* gpio = platform_gpio();
-		if (drv->clk[drv->clkout_id].output_enable) {
-			gpio_set(gpio->h1r9_clkout_en);
-		} else {
-			gpio_clear(gpio->h1r9_clkout_en);
-		}
-	}
-#endif
 }
 
 void si5351c_set_int_mode(
@@ -339,7 +328,7 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 	}
 }
 
-void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
+static void si5351c_clkout_ms_enable(si5351c_driver_t* const drv, bool enable)
 {
 	drv->clk[drv->clkout_id].output_enable = enable;
 	drv->clk[drv->clkout_id].power_down = !enable;
@@ -351,12 +340,42 @@ void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 	si5351c_enable_clock_outputs(drv);
 }
 
+void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
+{
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		const platform_gpio_t* gpio = platform_gpio();
+
+		/* CLKOUT is shared with MCU_CLK, enable MS when either on. */
+		bool mcu_clkin_enabled = gpio_read(gpio->h1r9_mcu_clk_en);
+		bool ms_needed = enable | mcu_clkin_enabled;
+		si5351c_clkout_ms_enable(drv, ms_needed);
+
+		/* Set GPIO to gate CLKOUT output downstream of MS. */
+		gpio_write(gpio->h1r9_clkout_en, enable);
+	}
+#endif
+#ifdef IS_NOT_H1_R9
+	if (IS_NOT_H1_R9) {
+		/* We have a dedicated CLKOUT multisynth. */
+		si5351c_clkout_ms_enable(drv, enable);
+	}
+#endif
+}
+
 void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
 {
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
-		/* MCU clock is shared with CLKOUT. */
-		si5351c_clkout_enable(drv, enable);
+		const platform_gpio_t* gpio = platform_gpio();
+
+		/* MCU_CLK is shared with CLKOUT, enable MS when either on. */
+		bool clkout_enabled = gpio_read(gpio->h1r9_clkout_en);
+		bool ms_needed = enable | clkout_enabled;
+		si5351c_clkout_ms_enable(drv, ms_needed);
+
+		/* Set GPIO to gate MCU_CLK output downstream of MS. */
+		gpio_write(gpio->h1r9_mcu_clk_en, enable);
 	}
 #endif
 #ifdef IS_NOT_H1_R9


### PR DESCRIPTION
On HackRF One r9, the `CLKOUT` and `MCU_CLK` clocks use the same Si5351A multisynth and output (CLK2).

Enabling and disabling the two outputs individually is achieved by downstream logic driven by the `CLKOUT_EN` and `MCU_CLK_EN` signals.

The work in #1751 to add control of the MCU clock still had some bugs on r9:

1. Calling `si5351c_mcu_clkin_enable(drv, true)` called `si5351c_clkout_enable` in turn to enable the shared clock, but never set the `MCU_CLK_EN` GPIO to gate that clock further downstream, so the MCU did not actually receive a clock.
2. Calling `si5351c_mcu_clkin_enable(drv, true)` had the side effect of turning on the `CLKOUT_EN` signal despite `CLKOUT` not being requested.
3. If both `CLKOUT` and `MCU_CLK` were enabled, calling either `si5351c_clkout_enable(drv, false)` or `si5351c_mcu_clkin_enable(drv, false)` would break the other clock by disabling the shared multisynth.

Fix this by making both functions check the state of the other clock output, and control the multisynth and GPIOs accordingly.

