### PR TITLE
Simplify PortaPack detection and init API

### DIFF
--- a/firmware/common/clock_gen.c
+++ b/firmware/common/clock_gen.c
@@ -131,7 +131,7 @@ clock_source_t activate_best_clock_source(void)
 #ifdef IS_EXPANSION_COMPATIBLE
 	if (IS_EXPANSION_COMPATIBLE) {
 		/* Ensure PortaPack reference oscillator is off while checking for external clock input. */
-		if (portapack_reference_oscillator && portapack()) {
+		if (portapack_present()) {
 			portapack_reference_oscillator(false);
 		}
 	}
@@ -146,7 +146,7 @@ clock_source_t activate_best_clock_source(void)
 #ifdef IS_EXPANSION_COMPATIBLE
 		if (IS_EXPANSION_COMPATIBLE) {
 			/* Enable PortaPack reference oscillator (if present), and check for valid clock. */
-			if (portapack_reference_oscillator && portapack()) {
+			if (portapack_present()) {
 				portapack_reference_oscillator(true);
 				delay_ms(18); // for oscillator to enable.
 				if (si5351c_clkin_signal_valid(&si5351c)) {

--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -610,23 +610,23 @@ static bool portapack_detect(void)
 	return idcode == 0x020A50DD || idcode == 0x00025610;
 }
 
-static const portapack_t portapack_instance = {};
+static bool portapack_detected = false;
 
-static const portapack_t* portapack_pointer = NULL;
-
-const portapack_t* portapack(void)
+bool portapack_present(void)
 {
-	return portapack_pointer;
+	return portapack_detected;
 }
 
-void portapack_init(void)
+bool portapack_init(void)
 {
 	if (portapack_detect()) {
 		portapack_if_init();
 		portapack_lcd_reset();
 		portapack_lcd_init();
-		portapack_pointer = &portapack_instance;
+		portapack_detected = true;
 	} else {
-		portapack_pointer = NULL;
+		portapack_detected = false;
 	}
+
+	return portapack_detected;
 }

--- a/firmware/common/portapack.h
+++ b/firmware/common/portapack.h
@@ -63,15 +63,13 @@ typedef struct {
 typedef struct {
 } portapack_t;
 
-void portapack_init(void);
+bool portapack_init(void);
 
-/* If the "portapack" symbol is defined, PortaPack support is compiled in */
-/* If the portapack() call returns non-NULL, a PortaPack was detected and is initialized. */
-const portapack_t* portapack(void) __attribute__((weak));
+bool portapack_present(void);
 
 void portapack_backlight(const bool on);
 
-void portapack_reference_oscillator(const bool on) __attribute__((weak));
+void portapack_reference_oscillator(const bool on);
 
 void portapack_fill_rectangle(const ui_rect_t rect, const ui_color_t color);
 

--- a/firmware/common/ui_portapack.c
+++ b/firmware/common/ui_portapack.c
@@ -760,7 +760,7 @@ const hackrf_ui_t portapack_hackrf_ui = {
 
 const hackrf_ui_t* portapack_hackrf_ui_init(void)
 {
-	if (portapack()) {
+	if (portapack_present()) {
 		return &portapack_hackrf_ui;
 	} else {
 		return NULL;


### PR DESCRIPTION
Previously, we had a somewhat overcomplicated method for PortaPack detection and conditional usage.

The `portapack` weak symbol was used to detect both whether PortaPack support was compiled-in (i.e. not `RAD1O` or `JAWBREAKER` builds), and if not `NULL`, could be called to detect whether a PortaPack was present at runtime, returning either a pointer to a  structure or `NULL`.

There was another weak symbol for `portapack_reference_oscillator` which could also be `NULL`.

Most of this logic has been obsoleted by our new platform logic in #1715, and at this point all we need is a simple boolean test for whether a PortaPack is present.

This PR provides that in the form of `portapack_present()`, and for convenience, also returns this from `portapack_init()`.