### PR TITLE
Make I2C startup & clock speed consistent

### DIFF
--- a/firmware/common/clock_gen.c
+++ b/firmware/common/clock_gen.c
@@ -24,8 +24,6 @@
 #include <stdint.h>
 
 #include "hackrf_ui.h"
-#include "i2c_bus.h"
-#include "i2c_lpc.h"
 #include "platform_detect.h"
 #include "sgpio.h"
 #include "si5351c.h"
@@ -36,8 +34,6 @@
 
 void clock_gen_init(void)
 {
-	i2c_bus_start(si5351c.bus, &i2c_config_fast_clock);
-
 	si5351c_init(&si5351c);
 	si5351c_disable_all_outputs(&si5351c);
 	si5351c_disable_oeb_pin_control(&si5351c);
@@ -120,7 +116,6 @@ void clock_gen_init(void)
 
 void clock_gen_shutdown(void)
 {
-	i2c_bus_start(si5351c.bus, &i2c_config_fast_clock);
 	si5351c_disable_all_outputs(&si5351c);
 	si5351c_disable_oeb_pin_control(&si5351c);
 	si5351c_power_down_all_clocks(&si5351c);

--- a/firmware/common/i2c_lpc.c
+++ b/firmware/common/i2c_lpc.c
@@ -25,6 +25,8 @@
 #include <libopencm3/lpc43xx/i2c.h>
 #include <libopencm3/lpc43xx/memorymap.h>
 
+#include "cpu_clock.h"
+
 /* Driver instances. */
 i2c_bus_t i2c0 = {
 	.obj = (void*) I2C0_BASE,
@@ -41,7 +43,7 @@ i2c_bus_t i2c1 = {
 };
 
 const i2c_lpc_config_t i2c_config_fast_clock = {
-	.duty_cycle_count = 255,
+	.clock_khz = 400,
 };
 
 /* FIXME return i2c0 status from each function */
@@ -51,7 +53,9 @@ void i2c_lpc_start(i2c_bus_t* const bus, const void* const _config)
 	const i2c_lpc_config_t* const config = _config;
 
 	const uint32_t port = (uint32_t) bus->obj;
-	i2c_init(port, config->duty_cycle_count);
+	const uint16_t duty_cycle_count =
+		(cpu_clock_mhz * (2000 / config->clock_khz)) / 4;
+	i2c_init(port, duty_cycle_count);
 }
 
 void i2c_lpc_stop(i2c_bus_t* const bus)

--- a/firmware/common/i2c_lpc.h
+++ b/firmware/common/i2c_lpc.h
@@ -29,7 +29,7 @@
 #include "i2c_bus.h"
 
 typedef struct {
-	const uint16_t duty_cycle_count;
+	const uint16_t clock_khz;
 } i2c_lpc_config_t;
 
 void i2c_lpc_start(i2c_bus_t* const bus, const void* const config);

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -36,6 +36,8 @@
 #include <delay.h>
 #include <fixed_point.h>
 #include <hackrf_ui.h>
+#include <i2c_bus.h>
+#include <i2c_lpc.h>
 #include <leds.h>
 #include <operacake.h>
 #include <mixer.h>
@@ -425,6 +427,8 @@ int main(void)
 	// Detect hardware platform before we do anything else.
 	detect_hardware_platform();
 	board_id_t board_id = detected_platform();
+
+	i2c_bus_start(&i2c0, &i2c_config_fast_clock);
 
 	pins_shutdown();
 	sgpio_pin_shutdown(&sgpio_config);

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -491,6 +491,9 @@ int main(void)
 #endif
 	cpu_clock_init();
 
+	/* Clock speed has changed, adjust I2C clock */
+	i2c_bus_start(&i2c0, &i2c_config_fast_clock);
+
 	/* Wake the M0 */
 	ipc_halt_m0();
 	ipc_start_m0((uint32_t) &__ram_m0_start__);


### PR DESCRIPTION
Both the `clock_gen_init` and `clock_gen_shutdown` functions included calls to `i2c_bus_start`.

The call was needed in both functions since `clock_gen_shutdown` can be called first to shut down the Si5351 outputs initially before bringing everything up from scratch.

We want the `clock_gen` code to be reusable and independent of `i2c_lpc`, so these calls shouldn't really live there. So the first change here is to make the call once from `main` instead.

While looking at this I noted that these functions would initially be running with the main clock at 96MHz, but the duty cycle is calculated for the 204MHz clock, so the I2C bus to the Si5351 initially runs at ~188kHz rather than 400kHz.

Since we now have the `cpu_clock_mhz` variable to consult from #1766, we can instead specify a speed in kHz, and have `i2c_lpc_start` calculate the necessary period for the current clock.

With that change, plus an additional call to `i2c_bus_start` after the PLL step to 204MHz, our I2C speed is now consistent.