### PR TITLE
CI: Adjust CMake generators to supported Visual Studio versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos', 'ubuntu', 'windows']
-        cmake: ['3.10.0', 'latest']
+        cmake: ['3.10.0', '3.21.7', '4.2.6', 'latest']
         compiler: ['gcc', 'msvc']
         exclude:
           # MSVC only runs on Windows.
@@ -26,13 +26,14 @@ jobs:
             compiler: 'msvc'
           - os: 'ubuntu'
             compiler: 'msvc'
-          # Only use the latest CMake on Windows. For MSVC, we can't use
-          # older CMake versions since the GitHub runners only have the
-          # latest Visual Studio release installed, and older CMake VS
-          # generators won't work. For GCC, we get curent CMake from the
-          # MSYS2 packages.
+          # We can't use the oldest CMake versions on Windows.
           - os: 'windows'
             cmake: '3.10.0'
+          # The in-between CMake versions aren't so intersting with GCC.
+          - compiler: 'gcc'
+            cmake: '3.21.7'
+          - compiler: 'gcc'
+            cmake: '4.2.6'
         include:
           # Shell selection
           - os: 'macos'
@@ -45,17 +46,31 @@ jobs:
           - os: 'windows'
             compiler: 'gcc'
             shell: 'msys2'
+          # MSVC version selection
+          - cmake: '3.21.7'
+            msvc: '17.14'
+          - cmake: '4.2.6'
+            msvc: 'latest'
+          - cmake: 'latest'
+            msvc: 'latest'
           # CMake generator selection
           - os: 'macos'
             generator: 'Unix Makefiles'
           - os: 'ubuntu'
             generator: 'Unix Makefiles'
-          - os: 'windows'
-            compiler: 'msvc'
+          - compiler: 'msvc'
+            cmake: '3.21.7'
+            generator: 'Visual Studio 17 2022'
+          - compiler: 'msvc'
+            cmake: '4.2.6'
+            generator: 'Visual Studio 18 2026'
+          - compiler: 'msvc'
+            cmake: 'latest'
             generator: 'Visual Studio 18 2026'
           - os: 'windows'
             compiler: 'gcc'
             generator: 'MSYS Makefiles'
+          # Additional CMake arguments
           - os: 'windows'
             compiler: 'msvc'
             cmake_args: >-
@@ -71,6 +86,10 @@ jobs:
             install_cmd: --build
             install_args: --target install
           # Later versions just use --install
+          - cmake: '3.21.7'
+            install_cmd: --install
+          - cmake: '4.2.6'
+            install_cmd: --install
           - cmake: 'latest'
             install_cmd: --install
           # We need sudo on MacOS and Ubuntu only
@@ -96,6 +115,12 @@ jobs:
       with:
         cmakeVersion: ${{ matrix.cmake }}
       if: matrix.shell != 'msys2'
+
+    - name: Install MSVC (Windows)
+      uses: k3DW/setup-msvc@v1
+      with:
+        vs-version: ${{ matrix.msvc }}
+      if: matrix.compiler == 'msvc' && matrix.msvc != 'latest'
 
     - name: Install dependencies (macOS)
       run: brew install fftw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,44 +17,63 @@ jobs:
   host:
     strategy:
       matrix:
-        sys:
-          - {os: 'macos', shell: 'bash'}
-          - {os: 'ubuntu', shell: 'bash'}
-          - {os: 'windows', shell: 'pwsh'}
-          - {os: 'windows', shell: 'msys2'}
-        cmake: ['3.10.0', '3.16.0', '3.21.0', '4.0.0', 'latest']
+        os: ['macos', 'ubuntu', 'windows']
+        cmake: ['3.10.0', 'latest']
+        compiler: ['gcc', 'msvc']
         exclude:
-          # GitHub runners use Visual Studio 2022. Support added in CMake 3.21.
-          - sys: {os: 'windows', shell: 'pwsh'}
+          # MSVC only runs on Windows.
+          - os: 'macos'
+            compiler: 'msvc'
+          - os: 'ubuntu'
+            compiler: 'msvc'
+          # Only use the latest CMake on Windows. For MSVC, we can't use
+          # older CMake versions since the GitHub runners only have the
+          # latest Visual Studio release installed, and older CMake VS
+          # generators won't work. For GCC, we get curent CMake from the
+          # MSYS2 packages.
+          - os: 'windows'
             cmake: '3.10.0'
-          - sys: {os: 'windows', shell: 'pwsh'}
-            cmake: '3.16.0'
-          # MSYS2 always supplies the latest cmake.
-          - sys: {os: 'windows', shell: 'msys2'}
-            cmake: '3.10.0'
-          - sys: {os: 'windows', shell: 'msys2'}
-            cmake: '3.16.0'
-          - sys: {os: 'windows', shell: 'msys2'}
-            cmake: '3.21.0'
-          - sys: {os: 'windows', shell: 'msys2'}
-            cmake: '4.0.0'
         include:
-          - sys: {os: 'windows', shell: 'pwsh'}
+          # Shell selection
+          - os: 'macos'
+            shell: 'bash'
+          - os: 'ubuntu'
+            shell: 'bash'
+          - os: 'windows'
+            compiler: 'msvc'
+            shell: 'pwsh'
+          - os: 'windows'
+            compiler: 'gcc'
+            shell: 'msys2'
+          # CMake generator selection
+          - os: 'macos'
+            generator: 'Unix Makefiles'
+          - os: 'ubuntu'
+            generator: 'Unix Makefiles'
+          - os: 'windows'
+            compiler: 'msvc'
+            generator: 'Visual Studio 18 2026'
+          - os: 'windows'
+            compiler: 'gcc'
+            generator: 'MSYS Makefiles'
+          - os: 'windows'
+            compiler: 'msvc'
             cmake_args: >-
               -DPKG_CONFIG_EXECUTABLE=C:/vcpkg/installed/x64-windows/tools/pkgconf/pkgconf.exe
               -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
               --install-prefix=$env:GITHUB_WORKSPACE/install
-          - sys: {os: 'windows', shell: 'msys2'}
+          - os: 'windows'
+            compiler: 'gcc'
             cmake_args: >-
               --install-prefix=/usr/local
 
       # Don't cancel all builds when one fails
       fail-fast: false
-    runs-on: ${{ matrix.sys.os }}-latest
+    runs-on: ${{ matrix.os }}-latest
 
     defaults:
       run:
-        shell: '${{ matrix.sys.shell }} {0}'
+        shell: '${{ matrix.shell }} {0}'
 
     steps:
     - uses: actions/checkout@v6
@@ -63,24 +82,24 @@ jobs:
       uses: lukka/get-cmake@latest
       with:
         cmakeVersion: ${{ matrix.cmake }}
-      if: matrix.sys.shell != 'msys2'
+      if: matrix.shell != 'msys2'
 
     - name: Install dependencies (macOS)
       run: brew install fftw
-      if: matrix.sys.os == 'macos'
+      if: matrix.os == 'macos'
 
     - name: Install dependencies (Ubuntu)
       run: |
         sudo apt update
         sudo apt install libfftw3-dev libusb-1.0-0-dev
-      if: matrix.sys.os == 'ubuntu'
+      if: matrix.os == 'ubuntu'
 
     - name: Install dependencies (Windows)
       run: vcpkg install --triplet=x64-windows libusb fftw3 pthreads pkgconf
-      if: matrix.sys.os == 'windows' && matrix.sys.shell != 'msys2'
+      if: matrix.os == 'windows' && matrix.shell != 'msys2'
 
     - name: Setup MSYS (Windows)
-      if: matrix.sys.os == 'windows' && matrix.sys.shell == 'msys2'
+      if: matrix.os == 'windows' && matrix.shell == 'msys2'
       uses: msys2/setup-msys2@v2
       with:
         msystem: UCRT64
@@ -98,7 +117,7 @@ jobs:
       run: |
         cmake -E make_directory host/build
         cd host/build
-        cmake .. -DCMAKE_BUILD_TYPE=Release ${{matrix.cmake_args}}
+        cmake .. -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release ${{matrix.cmake_args}}
         cmake --build . --config Release
 
     # Build libhackrf ONLY
@@ -107,22 +126,22 @@ jobs:
       run: |
         cmake -E make_directory host/libhackrf/build
         cd host/libhackrf/build
-        cmake .. -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
+        cmake .. -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
         cmake --build . --config Release
 
     - name: Install (libhackrf)
       run: |
         sudo cmake --install host/libhackrf/build --config Release
-      if: matrix.sys.os != 'windows' && matrix.cmake != '3.10.0'
+      if: matrix.os != 'windows' && matrix.cmake != '3.10.0'
 
     - name: Install (libhackrf, CMake 3.10)
       run: |
         sudo cmake --build host/libhackrf/build --target install --config Release
-      if: matrix.sys.os != 'windows' && matrix.cmake == '3.10.0'
+      if: matrix.os != 'windows' && matrix.cmake == '3.10.0'
 
     - name: Install (libhackrf, Windows)
       run: cmake --install host/libhackrf/build --config Release
-      if: matrix.sys.os == 'windows'
+      if: matrix.os == 'windows'
 
     # Build hackrf-tools ONLY
 
@@ -130,22 +149,22 @@ jobs:
       run: |
         cmake -E make_directory host/hackrf-tools/build
         cd host/hackrf-tools/build
-        cmake .. -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
+        cmake .. -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_args }}
         cmake --build . --config Release
 
     - name: Install (hackrf-tools)
       run: |
         sudo cmake --install host/hackrf-tools/build --config Release
-      if: matrix.sys.os != 'windows' && matrix.cmake != '3.10.0'
+      if: matrix.os != 'windows' && matrix.cmake != '3.10.0'
 
     - name: Install (hackrf-tools, CMake 3.10)
       run: |
         sudo cmake --build host/hackrf-tools/build --target install --config Release
-      if: matrix.sys.os != 'windows' && matrix.cmake == '3.10.0'
+      if: matrix.os != 'windows' && matrix.cmake == '3.10.0'
 
     - name: Install (hackrf-tools, Windows)
       run: cmake --install host/hackrf-tools/build --config Release
-      if: matrix.sys.os == 'windows'
+      if: matrix.os == 'windows'
 
     # Publish the contents of install/bin (which should be the combination libhackrf and host-tools) for Windows
     - name: Publish Artifacts (Windows)
@@ -153,7 +172,7 @@ jobs:
       with:
         name: hackrf-tools-windows
         path: ${{github.workspace}}/install/bin
-      if: matrix.sys.os == 'windows' && matrix.cmake == 'latest' && matrix.sys.shell == 'pwsh'
+      if: matrix.os == 'windows' && matrix.cmake == 'latest' && matrix.shell == 'pwsh'
 
   firmware:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         shell: '${{ matrix.sys.shell }} {0}'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup cmake
       uses: lukka/get-cmake@latest
@@ -179,7 +179,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,19 @@ jobs:
             compiler: 'gcc'
             cmake_args: >-
               --install-prefix=/usr/local
+          # CMake 3.10 uses --build with --target install
+          - cmake: '3.10.0'
+            install_cmd: --build
+            install_args: --target install
+          # Later versions just use --install
+          - cmake: 'latest'
+            install_cmd: --install
+          # We need sudo on MacOS and Ubuntu only
+          - os: macos
+            sudo: sudo
+          - os: ubuntu
+            sudo: sudo
+
 
       # Don't cancel all builds when one fails
       fail-fast: false
@@ -131,17 +144,7 @@ jobs:
 
     - name: Install (libhackrf)
       run: |
-        sudo cmake --install host/libhackrf/build --config Release
-      if: matrix.os != 'windows' && matrix.cmake != '3.10.0'
-
-    - name: Install (libhackrf, CMake 3.10)
-      run: |
-        sudo cmake --build host/libhackrf/build --target install --config Release
-      if: matrix.os != 'windows' && matrix.cmake == '3.10.0'
-
-    - name: Install (libhackrf, Windows)
-      run: cmake --install host/libhackrf/build --config Release
-      if: matrix.os == 'windows'
+        ${{ matrix.sudo }} cmake ${{ matrix.install_cmd }} host/libhackrf/build ${{ matrix.install_args }} --config Release
 
     # Build hackrf-tools ONLY
 
@@ -154,17 +157,7 @@ jobs:
 
     - name: Install (hackrf-tools)
       run: |
-        sudo cmake --install host/hackrf-tools/build --config Release
-      if: matrix.os != 'windows' && matrix.cmake != '3.10.0'
-
-    - name: Install (hackrf-tools, CMake 3.10)
-      run: |
-        sudo cmake --build host/hackrf-tools/build --target install --config Release
-      if: matrix.os != 'windows' && matrix.cmake == '3.10.0'
-
-    - name: Install (hackrf-tools, Windows)
-      run: cmake --install host/hackrf-tools/build --config Release
-      if: matrix.os == 'windows'
+        ${{ matrix.sudo }} cmake ${{ matrix.install_cmd }} host/hackrf-tools/build ${{ matrix.install_args }}
 
     # Publish the contents of install/bin (which should be the combination libhackrf and host-tools) for Windows
     - name: Publish Artifacts (Windows)

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -16,7 +16,7 @@ jobs:
           - check: 'firmware/hackrf_usb'
             exclude: ''
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run clang-format-action
       uses: jidicula/clang-format-action@v4.6.2
       with:


### PR DESCRIPTION
Fixes CI failures caused by GitHub's runners updating to Visual Studio 18 2026.

Support for VS18 was added in CMake 4.2, so our Windows runs on earlier CMake versions were failing.

This PR fixes that by using k3DW's [setup-msvc](https://github.com/k3DW/setup-msvc) action to install VS17 and use it with CMake 3.21.

Also bumps us to `actions/checkout@v6` to avoid warnings about actions still using Node 20.