### PR TITLE
libhackrf: fix endianness on max2837/max2831/rffc5071 register reads

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -987,6 +987,7 @@ int ADDCALL hackrf_max2837_read(
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
 	} else {
+		*value = FROM_LE16(*value);
 		return HACKRF_SUCCESS;
 	}
 }
@@ -1016,6 +1017,7 @@ int ADDCALL hackrf_max2831_read(
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
 	} else {
+		*value = FROM_LE16(*value);
 		return HACKRF_SUCCESS;
 	}
 }
@@ -1200,6 +1202,7 @@ int ADDCALL hackrf_rffc5071_read(
 		last_libusb_error = result;
 		return HACKRF_ERROR_LIBUSB;
 	} else {
+		*value = FROM_LE16(*value);
 		return HACKRF_SUCCESS;
 	}
 }


### PR DESCRIPTION
Fixes #778.

`hackrf_max2837_read`, `hackrf_max2831_read`, and `hackrf_rffc5071_read` all cast the raw 2-byte USB control-transfer buffer directly to `uint16_t*` and return it as-is, with no byte-order conversion. That only gives the right answer on a little-endian host, because the firmware always puts the register value on the wire little-endian.

A few lines down, `hackrf_read_adc` does the same kind of read but correctly converts with `*value = FROM_LE16(*value);`, and `hackrf_board_partid_serialno_read` does the same for its fields. The `FROM_LE16` macro is already defined at the top of `hackrf.c` and compiles to a no-op on little-endian, `__builtin_bswap16` on big-endian. These three reads just never got it applied.

This came up in #778 back in 2020. The maintainer's reply at the time ("I think it's correct... it gets loaded into the buffer as little-endian on the firmware side") is true but answers a different question - the firmware side being little-endian is exactly why the host needs to swap on a big-endian host. The original reporter clarified this in a follow-up comment and said they'd send a PR, but it looks like that never happened, so here it is.

Change: add `*value = FROM_LE16(*value);` to the success path of all three functions, matching the existing pattern in `hackrf_read_adc`.

Testing: this is a no-op on little-endian hosts (x86/x86_64/aarch64/arm - the overwhelming majority of libhackrf builds), since `FROM_LE16` expands to `x` there, so there's no behavior change or regression risk for the common case. I don't have a big-endian machine or a HackRF on hand to test against right now, so I haven't been able to verify the swapped path against real hardware. The macro itself is already proven correct elsewhere in the same file (`hackrf_read_adc`, `hackrf_board_partid_serialno_read`), so this is applying an existing, working pattern rather than introducing new logic. Flagging that a spot-check on an actual big-endian build (or at least a unit test feeding a non-symmetric byte pair through the macro) would be good before merge if anyone has that hardware handy.
