### PR TITLE
fpga: Fixes to fixed-point arithmetic

### DIFF
--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -91,7 +91,7 @@ class Value(hdl.ValueCastable):
         
         # If we're reducing precision, perform convergent rounding (round to even).
         elif f_width < self.f_width:
-            return Shape(self.i_width, f_width, signed = self.signed)( convergent_round(self.raw(), self.f_width - f_width) )
+            return Shape(self.i_width + 1, f_width, signed = self.signed)( convergent_round(self.raw(), self.f_width - f_width) )
 
         return self
 

--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -236,7 +236,13 @@ class Value(hdl.ValueCastable):
             if other < 0:
                 raise ValueError("Shift amount cannot be negative")
 
-            return Value.cast(self.raw(), self.f_width + other)
+            value = self.raw()
+
+            if other > self.i_width:
+                extend = value[-1] if self.signed else hdl.Const(0)
+                value = hdl.Cat(value, extend.replicate(other - self.i_width))
+
+            return Value.cast(value, self.f_width + other, self.signed)
 
         elif not isinstance(other, hdl.Value):
             raise TypeError("Shift amount must be an integer value")

--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -26,14 +26,16 @@ class Shape(hdl.ShapeCastable):
         self.signed = bool(signed)
 
     @staticmethod
-    def cast(shape, f_width=0):
+    def cast(shape, f_width=0, signed=None):
         if not isinstance(shape, hdl.Shape):
             raise TypeError(f"Object {shape!r} cannot be converted to a fixed.Shape")
+        if signed == None:
+            signed = shape.signed
 
         # i_width is what's left after subtracting f_width and sign bit, but can't be negative.
-        i_width = max(0, shape.width - shape.signed - f_width)
+        i_width = max(0, shape.width - signed - f_width)
 
-        return Shape(i_width, f_width, signed = shape.signed)
+        return Shape(i_width, f_width, signed = signed)
 
     def as_shape(self):
         return hdl.Shape(self.signed + self.i_width + self.f_width, self.signed)
@@ -81,8 +83,8 @@ class Value(hdl.ValueCastable):
         self._target = target
 
     @staticmethod
-    def cast(value, f_width=0):
-        return Shape.cast(value.shape(), f_width)(value)
+    def cast(value, f_width=0, signed=None):
+        return Shape.cast(value.shape(), f_width, signed)(value)
 
     def round(self, f_width=0):
         # If we're increasing precision, extend with more fractional bits.

--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -219,7 +219,7 @@ class Value(hdl.ValueCastable):
                 raise ValueError("Shift amount cannot be negative")
 
             if other > self.f_width:
-                return Value.cast(hdl.Cat(hdl.Const(0, other - self.f_width), self.raw()))
+                return Value.cast(hdl.Cat(hdl.Const(0, other - self.f_width), self.raw()), signed = self.signed)
             else:
                 return Value.cast(self.raw(), self.f_width - other)
 

--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -79,6 +79,8 @@ class UQ(Shape):
 
 class Value(hdl.ValueCastable):
     def __init__(self, shape, target):
+        if target.shape().width != shape.as_shape().width:
+            raise ValueError(f'attempting to create {shape} ({shape.as_shape().width} bits) from {target.shape()} value')
         self._shape = shape
         self._target = target
 

--- a/firmware/fpga/amaranth_future/fixed.py
+++ b/firmware/fpga/amaranth_future/fixed.py
@@ -115,12 +115,12 @@ class Value(hdl.ValueCastable):
 
     def raw(self):
         """
-        Adding an `s ( )` signedness wrapper in `as_value` when needed
+        Adding an `s ( )` or `u ( )` signedness wrapper in `as_value` when needed
         breaks lib.wiring for some reason. In the future, raw() and
         `as_value()` should be combined.
         """
-        if self.signed:
-            return self._target.as_signed()
+        if self._target.shape().signed != self.signed:
+            return self._target.as_signed() if self.signed else self._target.as_unsigned()
         return self._target
 
     def shape(self):

--- a/firmware/fpga/dsp/fir.py
+++ b/firmware/fpga/dsp/fir.py
@@ -308,7 +308,7 @@ class FIRFilter(wiring.Component):
         muls = []
         for i, tap in enumerate(self.taps):
             tap_fixed = fixed.Const(tap)
-            muls.append([ fixed.Value.cast(mcm.output.p[c][f"{i}"], tap_fixed.f_width + self.shape.f_width) for c in range(self.num_channels) ])
+            muls.append([ fixed.Value.cast(mcm.output.p[c][f"{i}"], self.shape.f_width) >> tap_fixed.f_width for c in range(self.num_channels) ])
 
         # Implement adder line.
         with m.If(~self.output.valid | self.output.ready):

--- a/firmware/fpga/dsp/fir_mac16.py
+++ b/firmware/fpga/dsp/fir_mac16.py
@@ -434,7 +434,7 @@ class SerialMAC16(wiring.Component):
                 m.d.sync += sum_carry_q.eq(self.sum_carry)
 
         m.submodules.dsp = dsp = iCE40Multiplier(
-            o_width=shape_out.as_shape().width,
+            o_width=shape_out.as_shape().width, p_width=shape_out.as_shape().width,
             always_ready=self.always_ready)
 
         valid_cnt = Signal(depth, init=1)

--- a/firmware/fpga/dsp/round.py
+++ b/firmware/fpga/dsp/round.py
@@ -17,8 +17,11 @@ def convergent_round(value, discarded_bits):
     # - If discarded > 0.5
     # - If discarded == 0.5 and retained is odd
     round_up = msb_discarded & (rest_discarded.any() | lsb_retained)
-    if len(retained) == 0:
+    if shape.signed:
+        retained = retained.as_signed()
+    if len(retained) - shape.signed == 0:
         # the returned result's width should always be 1 more than retained,
-        # and Amaranth would produce 2 bits if we did the addition
-        return round_up
+        # but in this case Amaranth addition produces 2 bits more
+        value = (retained + round_up)[:-1]
+        return value.as_signed() if shape.signed else value
     return retained + round_up

--- a/firmware/fpga/dsp/round.py
+++ b/firmware/fpga/dsp/round.py
@@ -5,13 +5,20 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 def convergent_round(value, discarded_bits):
+    shape = value.shape()
+    if discarded_bits > shape.width - shape.signed:
+        raise ValueError(f'cannot discard {discarded_bits} bits from a value with {shape.width - shape.signed} non-sign bits')
     retained = value[discarded_bits:]
     discarded = value[:discarded_bits]
     msb_discarded = discarded[-1]
     rest_discarded = discarded[:-1]
-    lsb_retained = retained[0]
+    lsb_retained = retained[0] if len(retained) else 0
     # Round up:
     # - If discarded > 0.5
     # - If discarded == 0.5 and retained is odd
     round_up = msb_discarded & (rest_discarded.any() | lsb_retained)
+    if len(retained) == 0:
+        # the returned result's width should always be 1 more than retained,
+        # and Amaranth would produce 2 bits if we did the addition
+        return round_up
     return retained + round_up


### PR DESCRIPTION
Hello! While reviewing the code for the fixed-point types I found a flurry of, in some cases clear bugs, in others unintuitive behavior at least.
I'm aware this code was copied from somewhere else, I just haven't yet had time to check where each issue was introduced so I can send each patch to the most upstream place.
These are the issues I found, each one has an associated patch (I can squash them all into one if preferred):

- **`convergent_round()` returns incorrect result when argument is negative:** `convergent_round` seems to be written without support for signed values, so for example -13 (which is -3.25 in SQ2.2) rounds to 5 rather than -3. Note that doing `.as_signed()` on the result is not enough; the problem is that the `retained + round_up` addition is performed with unsigned inputs, and therefore `retained` is not correctly extended and the output MSB is wrong.

  This of course affects `fixed.Value.round()` and all of its usages. I believe current usages in `dsp` manage not to hit this because they immediately assign the rounded value to a signal in a way that drops the faulty MSB and signedness.

- **`convergent_round()` fails when `len(value) == discarded_bits`:** while this is a more questionable edge case, it means that under very specific arguments `fixed.Value.eq()` fails (namely when self's f_width == 0 and other is unsigned, i_width == 0 and f_width > 0). I believe it makes perfect sense for `convergent_round` to handle this case, so I fixed it there.

- **`fixed.Value.round()` returns malformed value:** when dropping precision, a `fixed.Value` is returned whose inner `hdl.Value` does not have a width matching `as_shape().width`. This is because rounding produces an extra carry bit, but the code fails to reflect this in the shape by increasing `i_width`.

- **`fixed.Value.__lshift__()` sometimes returns incorrect result:** the optimization for when `other` is an `int` is not correct, because in some cases it returns a different value than what would be returned if `other` were wrapped in `Const`. This is because `Cat` drops the signedness, thus `fixed.Value.cast()` reinterprets the value as if it were unsigned. For example, `fixed.Const(-3.25) << 3` returns 38, while `fixed.Const(-3.25) << Const(3)` returns -26 as expected.

- **`fixed.Value.__rshift__()` sometimes returns malformed value:** the optimization for when `other` is an `int` is not correct, because in some cases it returns a `fixed.Value` whose inner `hdl.Value` does not have a width that matches `as_shape().width`. This malformed value can later fail to round, as the raw value has less bits than expected.

- **`fixed.Value.raw()` does not preserve signedness for unsigned values:** it's less clear this is a bug, but I believe `raw()` should always return an `hdl.Value` of the signedness specified by `shape.signed`, and it currently fails to do that when `_target` is signed but `shape` is not. Plus it adds the `as_signed()` wrapper even when it's not needed, affecting readability and assignability.

Two of the issues above were related to malformed values, so I've also added an assertion in `__init__` to catch mistakes like those in the future. This revealed two other creations of malformed values in `dsp` code which were easy to fix.
