### PR TITLE
libhackrf: destroy mutex/cond var on hackrf_open_setup() error paths

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -805,6 +805,7 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 
 	result = pthread_cond_init(&lib_device->all_finished_cv, NULL);
 	if (result != 0) {
+		pthread_mutex_destroy(&lib_device->transfer_lock);
 		free(lib_device);
 		libusb_release_interface(usb_device, 0);
 		libusb_close(usb_device);
@@ -813,6 +814,9 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 
 	result = allocate_transfers(lib_device);
 	if (result != 0) {
+		free_transfers(lib_device);
+		pthread_mutex_destroy(&lib_device->transfer_lock);
+		pthread_cond_destroy(&lib_device->all_finished_cv);
 		free(lib_device);
 		libusb_release_interface(usb_device, 0);
 		libusb_close(usb_device);
@@ -821,6 +825,9 @@ static int hackrf_open_setup(libusb_device_handle* usb_device, hackrf_device** d
 
 	result = create_transfer_thread(lib_device);
 	if (result != 0) {
+		free_transfers(lib_device);
+		pthread_mutex_destroy(&lib_device->transfer_lock);
+		pthread_cond_destroy(&lib_device->all_finished_cv);
 		free(lib_device);
 		libusb_release_interface(usb_device, 0);
 		libusb_close(usb_device);


### PR DESCRIPTION
`hackrf_open_setup()` in `host/libhackrf/src/hackrf.c` initializes `lib_device->transfer_lock` (a pthread mutex) and `lib_device->all_finished_cv` (a pthread cond var) partway through setup, then keeps going to allocate transfer buffers and spawn the transfer thread. If any of those later steps fail, the error path frees `lib_device` itself but never calls `pthread_mutex_destroy()` / `pthread_cond_destroy()` on the two objects it already initialized, and never frees the transfer array `allocate_transfers()` may have partially built before failing.

`hackrf_close()` shows what the teardown is supposed to look like: `free_transfers()`, then `pthread_mutex_destroy()`, then `pthread_cond_destroy()`. The error paths in `hackrf_open_setup()` should do the same three things before freeing the device struct, they just don't.

This fixes the three error paths that come after the mutex is initialized:

- `pthread_cond_init()` failing now destroys the already-initialized mutex before freeing.
- `allocate_transfers()` failing now frees any transfers it managed to allocate and destroys both the mutex and cond var.
- `create_transfer_thread()` failing does the same.

I left the earlier `libusb_control_transfer()` failure path (just above, checking firmware buffer size) alone since the mutex/cond var aren't initialized yet at that point, that's a separate pre-existing leak of `lib_device` itself and out of scope for this fix.

This is a rare path (only hit when pthread init, an allocation, or a thread spawn actually fails), so I haven't been able to trigger it on real hardware to confirm the leak count with something like valgrind. The fix mirrors the exact cleanup sequence already used in `hackrf_close()`, so I'm confident in the logic, but I'd still call this untested on-device and would want someone to sanity check it against a debug build before it ships.
