### PR TITLE
Rename RADIO_BANK_ACTIVE to RADIO_BANK_REQUESTED

### DIFF
--- a/firmware/common/radio.c
+++ b/firmware/common/radio.c
@@ -54,7 +54,7 @@ void radio_init(radio_t* const radio)
 		}
 	}
 	radio->config[RADIO_BANK_APPLIED][RADIO_OPMODE] = TRANSCEIVER_MODE_OFF;
-	radio->config[RADIO_BANK_ACTIVE][RADIO_OPMODE] = TRANSCEIVER_MODE_OFF;
+	radio->config[RADIO_BANK_REQUESTED][RADIO_OPMODE] = TRANSCEIVER_MODE_OFF;
 	radio->config[RADIO_BANK_IDLE][RADIO_OPMODE] = TRANSCEIVER_MODE_OFF;
 	radio->config[RADIO_BANK_RX][RADIO_OPMODE] = TRANSCEIVER_MODE_RX;
 	radio->config[RADIO_BANK_TX][RADIO_OPMODE] = TRANSCEIVER_MODE_TX;
@@ -78,7 +78,7 @@ radio_error_t radio_reg_write(
 	}
 
 	switch (bank) {
-	case RADIO_BANK_ACTIVE:
+	case RADIO_BANK_REQUESTED:
 		mark_dirty(radio, reg);
 		/* fall through */
 	case RADIO_BANK_IDLE:
@@ -937,7 +937,7 @@ bool radio_update(radio_t* const radio)
 		return false;
 	}
 	radio->regs_dirty = 0;
-	memcpy(&tmp_bank[0], &(radio->config[RADIO_BANK_ACTIVE][0]), sizeof(tmp_bank));
+	memcpy(&tmp_bank[0], &(radio->config[RADIO_BANK_REQUESTED][0]), sizeof(tmp_bank));
 	nvic_enable_irq(NVIC_USB0_IRQ);
 
 	if ((dirty & RADIO_REG_GROUP_RATE) ||
@@ -998,14 +998,14 @@ void radio_switch_opmode(radio_t* const radio, const transceiver_mode_t mode)
 	nvic_disable_irq(NVIC_USB0_IRQ);
 	for (uint8_t reg = 0; reg < RADIO_NUM_REGS; reg++) {
 		value = radio->config[source_bank][reg];
-		previous = radio->config[RADIO_BANK_ACTIVE][reg];
+		previous = radio->config[RADIO_BANK_REQUESTED][reg];
 		if ((value != RADIO_UNSET) && (value != previous)) {
-			radio->config[RADIO_BANK_ACTIVE][reg] = value;
+			radio->config[RADIO_BANK_REQUESTED][reg] = value;
 			mark_dirty(radio, reg);
 		}
 	}
 
-	radio->config[RADIO_BANK_ACTIVE][RADIO_OPMODE] = mode;
+	radio->config[RADIO_BANK_REQUESTED][RADIO_OPMODE] = mode;
 	mark_dirty(radio, RADIO_OPMODE);
 	nvic_enable_irq(NVIC_USB0_IRQ);
 	radio_update(radio);

--- a/firmware/common/radio.h
+++ b/firmware/common/radio.h
@@ -191,7 +191,7 @@ typedef enum {
 	 (1 << RADIO_GAIN_RX_IF) | (1 << RADIO_GAIN_RX_BB))
 
 /**
- * Register bank RADIO_BANK_ACTIVE stores the active configuration. Active
+ * Register bank RADIO_BANK_REQUESTED stores the active configuration. Active
  * register settings are copied to the applied register when applied.
  *
  * The other three banks store settings that will be applied when switching to
@@ -202,7 +202,7 @@ typedef enum {
  */
 typedef enum {
 	RADIO_BANK_APPLIED = 0,
-	RADIO_BANK_ACTIVE = 1,
+	RADIO_BANK_REQUESTED = 1,
 	RADIO_BANK_IDLE = 2,
 	RADIO_BANK_RX = 3,
 	RADIO_BANK_TX = 4,
@@ -237,7 +237,7 @@ typedef struct {
 void radio_init(radio_t* const radio);
 
 /**
- * Write to one or more registers. Writes to RADIO_BANK_ACTIVE are applied at
+ * Write to one or more registers. Writes to RADIO_BANK_REQUESTED are applied at
  * the next radio_update(). Writes to RADIO_BANK_APPLIED are not supported.
  */
 radio_error_t radio_reg_write(
@@ -255,7 +255,7 @@ uint64_t radio_reg_read(
 	const radio_register_t reg);
 
 /**
- * Apply changes requested in RADIO_BANK_ACTIVE.
+ * Apply changes requested in RADIO_BANK_REQUESTED.
  * Return true if any changes were applied.
  */
 bool radio_update(radio_t* const radio);

--- a/firmware/hackrf_usb/usb_api_sweep.c
+++ b/firmware/hackrf_usb/usb_api_sweep.c
@@ -132,7 +132,7 @@ usb_request_status_t usb_vendor_request_init_sweep(
 
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_RF,
 			(sweep_freq + offset) * FP_ONE_HZ);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -263,7 +263,7 @@ void sweep_mode(uint32_t seq)
 			nvic_disable_irq(NVIC_USB0_IRQ);
 			radio_reg_write(
 				&radio,
-				RADIO_BANK_ACTIVE,
+				RADIO_BANK_REQUESTED,
 				RADIO_FREQUENCY_RF,
 				(sweep_freq + offset) * FP_ONE_HZ);
 			nvic_enable_irq(NVIC_USB0_IRQ);

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -94,12 +94,12 @@ usb_request_status_t usb_vendor_request_set_baseband_filter_bandwidth(
 			(endpoint->setup.index << 16) | endpoint->setup.value;
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_BB_BANDWIDTH_TX,
 			bandwidth);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_BB_BANDWIDTH_RX,
 			bandwidth);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -123,22 +123,22 @@ usb_request_status_t usb_vendor_request_set_freq(
 			set_freq_params.freq_mhz * 1000000ULL + set_freq_params.freq_hz;
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_RF,
 			freq * FP_ONE_HZ);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_IF,
 			RADIO_UNSET);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_LO,
 			RADIO_UNSET);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_IMAGE_REJECT,
 			RADIO_UNSET);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -160,17 +160,17 @@ usb_request_status_t usb_vendor_request_set_freq_explicit(
 	} else if (stage == USB_TRANSFER_STAGE_DATA) {
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_IF,
 			explicit_params.if_freq_hz * FP_ONE_HZ);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_FREQUENCY_LO,
 			explicit_params.lo_freq_hz * FP_ONE_HZ);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_IMAGE_REJECT,
 			explicit_params.path);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -215,7 +215,7 @@ usb_request_status_t usb_vendor_request_set_sample_rate_frac(
 		uint32_t numerator = set_sample_r_params.freq_hz;
 		uint32_t denominator = set_sample_r_params.divider;
 		uint64_t value = round_sample_rate(numerator, denominator);
-		radio_reg_write(&radio, RADIO_BANK_ACTIVE, RADIO_SAMPLE_RATE, value);
+		radio_reg_write(&radio, RADIO_BANK_REQUESTED, RADIO_SAMPLE_RATE, value);
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;
@@ -228,12 +228,12 @@ usb_request_status_t usb_vendor_request_set_amp_enable(
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_GAIN_TX_RF,
 			endpoint->setup.value);
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_GAIN_RX_RF,
 			endpoint->setup.value);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -247,7 +247,7 @@ usb_request_status_t usb_vendor_request_set_lna_gain(
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		uint8_t gain = endpoint->setup.index;
-		radio_reg_write(&radio, RADIO_BANK_ACTIVE, RADIO_GAIN_RX_IF, gain);
+		radio_reg_write(&radio, RADIO_BANK_REQUESTED, RADIO_GAIN_RX_IF, gain);
 		endpoint->buffer[0] = RADIO_OK;
 		usb_transfer_schedule_block(
 			endpoint->in,
@@ -266,7 +266,7 @@ usb_request_status_t usb_vendor_request_set_vga_gain(
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		uint8_t gain = endpoint->setup.index;
-		radio_reg_write(&radio, RADIO_BANK_ACTIVE, RADIO_GAIN_RX_BB, gain);
+		radio_reg_write(&radio, RADIO_BANK_REQUESTED, RADIO_GAIN_RX_BB, gain);
 		endpoint->buffer[0] = RADIO_OK;
 		usb_transfer_schedule_block(
 			endpoint->in,
@@ -285,7 +285,7 @@ usb_request_status_t usb_vendor_request_set_txvga_gain(
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		uint8_t gain = endpoint->setup.index;
-		radio_reg_write(&radio, RADIO_BANK_ACTIVE, RADIO_GAIN_TX_IF, gain);
+		radio_reg_write(&radio, RADIO_BANK_REQUESTED, RADIO_GAIN_TX_IF, gain);
 		endpoint->buffer[0] = RADIO_OK;
 		usb_transfer_schedule_block(
 			endpoint->in,
@@ -315,7 +315,7 @@ usb_request_status_t usb_vendor_request_set_antenna_enable(
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_BIAS_TEE,
 			endpoint->setup.value);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -427,7 +427,7 @@ usb_request_status_t usb_vendor_request_set_hw_sync_mode(
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		radio_reg_write(
 			&radio,
-			RADIO_BANK_ACTIVE,
+			RADIO_BANK_REQUESTED,
 			RADIO_TRIGGER,
 			endpoint->setup.value);
 		usb_transfer_schedule_ack(endpoint->in);


### PR DESCRIPTION
It's easy to get confused about the meaning of `RADIO_BANK_ACTIVE` vs `RADIO_BANK_APPLIED`.

This PR renames `RADIO_BANK_ACTIVE` to `RADIO_BANK_REQUESTED` in order to clarify its usage as the register bank holding parameters that serve as the inputs to `radio_update_*()` methods and which are then applied to the hardware and stored into `RADIO_BANK_APPLIED`.

The new naming is consistent with local variable naming already in use e.g.:

```c
bool radio_update(radio_t* const radio)
{
    uint64_t tmp_bank[RADIO_NUM_REGS];
    ...
    memcpy(&tmp_bank[0], &(radio->config[RADIO_BANK_ACTIVE][0]), sizeof(tmp_bank));
    nvic_enable_irq(NVIC_USB0_IRQ);

    if ((dirty & RADIO_REG_GROUP_RATE) ||
        ((detected_platform() == BOARD_ID_PRALINE) &&
         (dirty & (1 << RADIO_OPMODE)))) {
        changed |= radio_update_sample_rate(radio, &tmp_bank[0]);
    }
    ...
```

```c
static uint32_t radio_update_sample_rate(radio_t* const radio, uint64_t* bank)
{
    ...
    const uint64_t requested_rate = bank[RADIO_SAMPLE_RATE];
    const uint64_t requested_correction = bank[RADIO_CLOCK_CORRECTION];
    ...
```

