### PR TITLE
libhackrf: Set a 500ms timeout for changing fpga bitstream

### DIFF
--- a/host/libhackrf/src/hackrf.c
+++ b/host/libhackrf/src/hackrf.c
@@ -57,6 +57,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #define DEFAULT_REQUEST_TIMEOUT 100
 #define CPLD_WRITE_TIMEOUT      10000
 #define SPIFLASH_WRITE_TIMEOUT  50000 // W25Q32JV max chip erase time
+#define FPGA_BITSTREAM_TIMEOUT  500
 
 // TODO: Factor this into a shared #include so that firmware can use
 // the same values.
@@ -3496,7 +3497,7 @@ int ADDCALL hackrf_set_fpga_bitstream(hackrf_device* device, const uint8_t index
 		0,
 		NULL,
 		0,
-		DEFAULT_REQUEST_TIMEOUT);
+		FPGA_BITSTREAM_TIMEOUT);
 
 	if (result != 0) {
 		last_libusb_error = result;


### PR DESCRIPTION
#1749 introduced timeouts on all USB control requests along with custom timeouts for CPLD writes and SPI flash/erase/writes.

This PR sets a 500ms timeout for `HACKRF_VENDOR_REQUEST_SET_FPGA_BITSTREAM` to avoid the request timing out during reconfiguration.

The value of 500ms was derived by taking the duration of the largest bitstream (`2_extprec_rx - 281ms`) and adding a small safety to give us a nice round number.