### PR TITLE
CI: Specify explicit URL for MSYS2 arm-none-eabi-binutils package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,6 +284,11 @@ jobs:
           mingw-w64-ucrt-x86_64-dfu-util
           mingw-w64-ucrt-x86_64-python-yaml
 
+    - name: Downgrade ARM linker (Windows, temporary)
+      if: matrix.os == 'windows'
+      shell: msys2 {0}
+      run: pacman -U --noconfirm https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-arm-none-eabi-binutils-2.46.1-1-any.pkg.tar.zst
+
     - name: Build with MSYS (Windows)
       if: matrix.os == 'windows'
       shell: msys2 {0}


### PR DESCRIPTION
Fixes #1807 by downgrading `mingw-w64-ucrt-x86_64-arm-none-eabi-binutils` to the previous version, `2.46.1-1`.

This should be reverted once MSYS2 ships a non-broken version of the linker.